### PR TITLE
Add `WithExpirationDate` `Expiration`

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -446,7 +446,7 @@ func TestCache_Remove(t *testing.T) {
 			name: "success - sharded",
 			c: func() Cache[string, string] {
 				c := NewSharded[string, string](2, DefaultStringHasher64{})
-				c.Set("foo", "foo", WithNoExpiration())
+				c.Set("foo", "foo", WithExpirationDate(time.Now().Add(time.Minute)))
 				return c
 			},
 			key: "foo",
@@ -465,7 +465,7 @@ func TestCache_Remove(t *testing.T) {
 			name: "entry expired - sharded",
 			c: func() Cache[string, string] {
 				c := NewSharded[string, string](8, DefaultStringHasher64{})
-				c.Set("foo", "foo", WithExpiration(time.Nanosecond))
+				c.Set("foo", "foo", WithExpirationDate(time.Now().Add(time.Nanosecond)))
 				<-time.After(time.Nanosecond)
 				return c
 			},

--- a/entry.go
+++ b/entry.go
@@ -2,11 +2,6 @@ package imcache
 
 import "time"
 
-type expiration struct {
-	date    int64
-	sliding time.Duration
-}
-
 // entry is the value stored in the cache.
 type entry[V any] struct {
 	val V

--- a/expiration.go
+++ b/expiration.go
@@ -7,6 +7,11 @@ const (
 	defaultExp = 0
 )
 
+type expiration struct {
+	date    int64
+	sliding time.Duration
+}
+
 // Expiration is the expiration time of an entry.
 type Expiration interface {
 	apply(*expiration)
@@ -22,6 +27,13 @@ func (f expirationf) apply(e *expiration) {
 func WithExpiration(d time.Duration) Expiration {
 	return expirationf(func(e *expiration) {
 		e.date = time.Now().Add(d).UnixNano()
+	})
+}
+
+// WithExpirationDate returns an Expiration that sets the expiration time to t.
+func WithExpirationDate(t time.Time) Expiration {
+	return expirationf(func(e *expiration) {
+		e.date = t.UnixNano()
 	})
 }
 


### PR DESCRIPTION
This PR adds `WithExpirationDate` `Expiration`.

It allows to set the exact expiration date for an entry.