### PR TITLE
Add `ReplaceWithFunc` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ func main() {
 	fmt.Println(got)
 	time.Sleep(1 * time.Second)
 
-    // Entry with key 2 should expire.
+	// Entry with key 2 should expire.
 	got, ok = c.Get(1)
 	if !ok {
 		panic("key 1 not found")

--- a/README.md
+++ b/README.md
@@ -13,3 +13,66 @@ It supports expiration, sliding expiration, eviction callbacks and sharding. It'
 ```Go
 import "github.com/erni27/imcache"
 ```
+
+## Usage
+
+```go
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/erni27/imcache"
+)
+
+func main() {
+	c := imcache.New[int32, string]()
+	// Add entries.
+	c.Set(1, "one", imcache.WithNoExpiration())
+	c.Set(2, "two", imcache.WithExpiration(2*time.Second))
+	c.Set(3, "three", imcache.WithSlidingExpiration(2*time.Second))
+	// Get the entries.
+	got, ok := c.Get(1)
+	if !ok {
+		panic("key 1 not found")
+	}
+	fmt.Println(got)
+	got, ok = c.Get(2)
+	if !ok {
+		panic("key 2 not found")
+	}
+	fmt.Println(got)
+	got, ok = c.Get(3)
+	if !ok {
+		panic("key 3 not found")
+	}
+	fmt.Println(got)
+
+	time.Sleep(1 * time.Second)
+	// Get the entry with key 3 to slide its expiration.
+	got, ok = c.Get(3)
+	if !ok {
+		panic("key 3 not found")
+	}
+	fmt.Println(got)
+	time.Sleep(1 * time.Second)
+
+    // Entry with key 2 should expire.
+	got, ok = c.Get(1)
+	if !ok {
+		panic("key 1 not found")
+	}
+	fmt.Println(got)
+	_, ok = c.Get(2)
+	if ok {
+		panic("key 2 found")
+	}
+	fmt.Println("entry with key 2 expired")
+	got, ok = c.Get(3)
+	if !ok {
+		panic("key 3 not found")
+	}
+	fmt.Println(got)
+}
+```

--- a/cache.go
+++ b/cache.go
@@ -46,6 +46,14 @@ type Cache[K comparable, V any] interface {
 	//
 	// If you want to replace the value with a new value not depending on the old value,
 	// use the Replace method instead.
+	//
+	// imcache provides the Increment and Decrement functions that can be used as f
+	// to increment or decrement the old value.
+	//
+	// Example:
+	//	c := imcache.New[string, int32]()
+	//	c.Set("foo", 997, imcache.WithNoExpiration())
+	//	_ = c.ReplaceWithFunc("foo", imcache.Increment[int32], imcache.WithNoExpiration())
 	ReplaceWithFunc(key K, f func(old V) (new V), exp Expiration) (present bool)
 	// Remove removes the cache entry for the given key.
 	//

--- a/cache.go
+++ b/cache.go
@@ -38,6 +38,15 @@ type Cache[K comparable, V any] interface {
 	//
 	// If you want to add or replace an entry, use the Set method instead.
 	Replace(key K, val V, exp Expiration) (present bool)
+	// ReplaceWithFunc replaces the value for the given key
+	// with the result of the given function that takes the old value as an argument.
+	// It returns true if the value is present and replaced, otherwise it returns false.
+	//
+	// If it encounters an expired entry, the expired entry is evicted.
+	//
+	// If you want to replace the value with a new value not depending on the old value,
+	// use the Replace method instead.
+	ReplaceWithFunc(key K, f func(old V) (new V), exp Expiration) (present bool)
 	// Remove removes the cache entry for the given key.
 	//
 	// It returns true if the entry is present and removed,
@@ -193,6 +202,33 @@ func (s *shard[K, V]) Replace(key K, val V, exp Expiration) bool {
 		}
 		return false
 	}
+	s.m[key] = entry
+	s.mu.Unlock()
+	if s.onEviction != nil {
+		s.onEviction(key, current.val, EvictionReasonReplaced)
+	}
+	return true
+}
+
+func (s *shard[K, V]) ReplaceWithFunc(key K, f func(V) V, exp Expiration) bool {
+	now := time.Now()
+	s.mu.Lock()
+	current, ok := s.m[key]
+	if !ok {
+		s.mu.Unlock()
+		return false
+	}
+	if current.HasExpired(now) {
+		delete(s.m, key)
+		s.mu.Unlock()
+		if s.onEviction != nil {
+			s.onEviction(key, current.val, EvictionReasonExpired)
+		}
+		return false
+	}
+	entry := entry[V]{val: f(current.val)}
+	exp.apply(&entry.exp)
+	entry.SetDefault(now, s.defaultExp, s.sliding)
 	s.m[key] = entry
 	s.mu.Unlock()
 	if s.onEviction != nil {
@@ -389,6 +425,10 @@ func (s *sharded[K, V]) GetOrSet(key K, val V, exp Expiration) (v V, present boo
 
 func (s *sharded[K, V]) Replace(key K, val V, exp Expiration) bool {
 	return s.shard(key).Replace(key, val, exp)
+}
+
+func (s *sharded[K, V]) ReplaceWithFunc(key K, fn func(V) V, exp Expiration) bool {
+	return s.shard(key).ReplaceWithFunc(key, fn, exp)
 }
 
 func (s *sharded[K, V]) Remove(key K) bool {

--- a/cache_test.go
+++ b/cache_test.go
@@ -400,6 +400,101 @@ func TestCache_Replace(t *testing.T) {
 	}
 }
 
+func TestCache_ReplaceWithFunc(t *testing.T) {
+	tests := []struct {
+		name    string
+		c       func() Cache[string, int32]
+		key     string
+		f       func(int32) int32
+		want    bool
+		val     int32
+		present bool
+	}{
+		{
+			name: "success",
+			c: func() Cache[string, int32] {
+				c := New[string, int32]()
+				c.Set("foo", 997, WithNoExpiration())
+				return c
+			},
+			key:     "foo",
+			f:       Increment[int32],
+			want:    true,
+			val:     998,
+			present: true,
+		},
+		{
+			name: "entry expired",
+			c: func() Cache[string, int32] {
+				c := New[string, int32]()
+				c.Set("foo", 997, WithExpiration(time.Nanosecond))
+				<-time.After(time.Nanosecond)
+				return c
+			},
+			key: "foo",
+			f:   Increment[int32],
+		},
+		{
+			name: "entry doesn't exist",
+			c: func() Cache[string, int32] {
+				c := New[string, int32]()
+				return c
+			},
+			key: "foo",
+			f:   Increment[int32],
+		},
+		{
+			name: "success - sharded",
+			c: func() Cache[string, int32] {
+				c := NewSharded[string, int32](2, DefaultStringHasher64{})
+				c.Set("foo", 997, WithNoExpiration())
+				return c
+			},
+			key:     "foo",
+			f:       Increment[int32],
+			want:    true,
+			val:     998,
+			present: true,
+		},
+		{
+			name: "entry expired - sharded",
+			c: func() Cache[string, int32] {
+				c := NewSharded[string, int32](4, DefaultStringHasher64{})
+				c.Set("foo", 997, WithExpiration(time.Nanosecond))
+				<-time.After(time.Nanosecond)
+				return c
+			},
+			key: "foo",
+			f:   Increment[int32],
+		},
+		{
+			name: "entry doesn't exist - sharded",
+			c: func() Cache[string, int32] {
+				c := NewSharded[string, int32](8, DefaultStringHasher64{})
+				return c
+			},
+			key: "foo",
+			f:   Increment[int32],
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := tt.c()
+			if ok := c.ReplaceWithFunc(tt.key, tt.f, WithDefaultExpiration()); ok != tt.present {
+				t.Fatalf("Cache.Replace(%s, _, _) = %t, want %t", tt.key, ok, tt.present)
+			}
+			got, ok := c.Get(tt.key)
+			if ok != tt.present {
+				t.Fatalf("Cache.Get(%s) = _, %t, want _, %t", tt.key, ok, tt.present)
+			}
+			if !cmp.Equal(got, tt.val) {
+				t.Errorf("Cache.Get(%s) = %v, _, want %v, _", tt.key, got, tt.val)
+			}
+		})
+	}
+}
+
 func TestCache_Remove(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -887,6 +982,46 @@ func TestCache_Replace_EvictionCallback(t *testing.T) {
 			}
 			if !evictioncMock.HasBeenCalledWith("bar", "bar", EvictionReasonReplaced) {
 				t.Errorf("want EvictionCallback called with EvictionCallback(%s, %s, %d)", "bar", "bar", EvictionReasonReplaced)
+			}
+		})
+	}
+}
+
+func TestCache_ReplaceWithFunc_EvictionCallback(t *testing.T) {
+	evictioncMock := &evictionCallbackMock{}
+
+	tests := []struct {
+		name string
+		c    Cache[string, interface{}]
+	}{
+		{
+			name: "not sharded",
+			c:    New(WithEvictionCallbackOption(evictioncMock.Callback)),
+		},
+		{
+			name: "sharded",
+			c:    NewSharded[string](8, DefaultStringHasher64{}, WithEvictionCallbackOption(evictioncMock.Callback)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer evictioncMock.Reset()
+			c := tt.c
+			c.Set("foo", 1, WithExpiration(time.Nanosecond))
+			c.Set("bar", 2, WithNoExpiration())
+			<-time.After(time.Nanosecond)
+			if ok := c.ReplaceWithFunc("foo", func(interface{}) interface{} { return 997 }, WithNoExpiration()); ok {
+				t.Errorf("Cache.Replace(%s, _, _) = %t, want false", "foo", ok)
+			}
+			if !evictioncMock.HasBeenCalledWith("foo", 1, EvictionReasonExpired) {
+				t.Errorf("want EvictionCallback called with EvictionCallback(%s, %d, %d)", "foo", 1, EvictionReasonExpired)
+			}
+			if ok := c.ReplaceWithFunc("bar", func(interface{}) interface{} { return 997 }, WithNoExpiration()); !ok {
+				t.Errorf("Cache.Replace(%s, _, _) = %t, want true", "bar", ok)
+			}
+			if !evictioncMock.HasBeenCalledWith("bar", 2, EvictionReasonReplaced) {
+				t.Errorf("want EvictionCallback called with EvictionCallback(%s, %d, %d)", "bar", 2, EvictionReasonReplaced)
 			}
 		})
 	}

--- a/cache_test.go
+++ b/cache_test.go
@@ -1243,12 +1243,12 @@ func TestCache_StartCleaner(t *testing.T) {
 			c := tt.c
 			c.Set("foo", "foo", WithExpiration(time.Millisecond))
 			c.Set("bar", "bar", WithExpiration(time.Millisecond))
-			c.Set("foobar", "foobar", WithExpiration(20*time.Millisecond))
-			c.StartCleaner(2 * time.Millisecond)
+			c.Set("foobar", "foobar", WithExpiration(100*time.Millisecond))
+			c.StartCleaner(20 * time.Millisecond)
 			// Subsequent calls to StartCleaner should not start a new cleaner.
 			c.StartCleaner(5 * time.Nanosecond)
 			c.StartCleaner(7 * time.Millisecond)
-			<-time.After(3 * time.Millisecond)
+			<-time.After(30 * time.Millisecond)
 			if !evictioncMock.HasBeenCalledWith("foo", "foo", EvictionReasonExpired) {
 				t.Errorf("want EvictionCallback called with EvictionCallback(%s, %s, %d)", "foo", "foo", EvictionReasonExpired)
 			}
@@ -1258,7 +1258,7 @@ func TestCache_StartCleaner(t *testing.T) {
 			if evictioncMock.HasBeenCalledWith("foobar", "foobar", EvictionReasonExpired) {
 				t.Errorf("want EvictionCallback not called with EvictionCallback(%s, %s, %d)", "foobar", "foobar", EvictionReasonExpired)
 			}
-			<-time.After(100 * time.Millisecond)
+			<-time.After(200 * time.Millisecond)
 			if !evictioncMock.HasBeenCalledWith("foobar", "foobar", EvictionReasonExpired) {
 				t.Errorf("want EvictionCallback called with EvictionCallback(%s, %s, %d)", "foobar", "foobar", EvictionReasonExpired)
 			}

--- a/cache_test.go
+++ b/cache_test.go
@@ -451,9 +451,9 @@ func TestCache_ReplaceWithFunc(t *testing.T) {
 				return c
 			},
 			key:     "foo",
-			f:       Increment[int32],
+			f:       Decrement[int32],
 			want:    true,
-			val:     998,
+			val:     996,
 			present: true,
 		},
 		{

--- a/increment.go
+++ b/increment.go
@@ -1,0 +1,9 @@
+package imcache
+
+type Number interface {
+	~float32 | ~float64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr | ~int | ~int8 | ~int16 | ~int32 | ~int64
+}
+
+func Increment[V Number](old V) V {
+	return old + 1
+}

--- a/increment.go
+++ b/increment.go
@@ -1,9 +1,16 @@
 package imcache
 
+// Number is a constraint that permits any numeric type except complex ones.
 type Number interface {
 	~float32 | ~float64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr | ~int | ~int8 | ~int16 | ~int32 | ~int64
 }
 
+// Increment increments the given number by one.
 func Increment[V Number](old V) V {
 	return old + 1
+}
+
+// Decrement decrements the given number by one.
+func Decrement[V Number](old V) V {
+	return old - 1
 }


### PR DESCRIPTION
This PR adds `ReplaceWithFunc` method.

It replaces the value for the given key with the result of the given function that takes the old value as an argument.