### PR TITLE
cleaner: return err instead of panic

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ It is possible to use the `Cleaner` to periodically remove expired entries from 
 ```go
 c := imcache.New[string, string]()
 // Start Cleaner which will remove expired entries every 5 minutes.
-c.StartCleaner(5 * time.Minute)
+_ = c.StartCleaner(5 * time.Minute)
+defer c.StopCleaner()
 ```
 
 To be notified when an entry is evicted from the cache, you can use the `EvictionCallback`. It's a function that accepts the key and value of the evicted entry along with the reason why the entry was evicted. `EvictionCallback` can be configured when creating a new `Cache` instance.

--- a/cache.go
+++ b/cache.go
@@ -85,10 +85,11 @@ type Cache[K comparable, V any] interface {
 	// StartCleaner starts a cleaner that periodically removes expired entries.
 	// A cleaner runs in a separate goroutine.
 	// It's a NOP method if the cleaner is already running.
-	// It panics if the interval is less than or equal to zero.
+	// It returns an error if the cleaner is already running
+	// or if the interval is less than or equal to zero.
 	//
 	// The cleaner can be stopped by calling StopCleaner method.
-	StartCleaner(interval time.Duration)
+	StartCleaner(interval time.Duration) error
 	// StopCleaner stops the cleaner.
 	// It is a blocking method that waits for the cleaner to stop.
 	// It's a NOP method if the cleaner is not running.
@@ -372,8 +373,8 @@ func (s *shard[K, V]) Len() int {
 	return n
 }
 
-func (s *shard[K, V]) StartCleaner(interval time.Duration) {
-	s.cleaner.start(s, interval)
+func (s *shard[K, V]) StartCleaner(interval time.Duration) error {
+	return s.cleaner.start(s, interval)
 }
 
 func (s *shard[K, V]) StopCleaner() {
@@ -483,8 +484,8 @@ func (s *sharded[K, V]) Len() int {
 	return n
 }
 
-func (s *sharded[K, V]) StartCleaner(interval time.Duration) {
-	s.cleaner.start(s, interval)
+func (s *sharded[K, V]) StartCleaner(interval time.Duration) error {
+	return s.cleaner.start(s, interval)
 }
 
 func (s *sharded[K, V]) StopCleaner() {

--- a/cleaner.go
+++ b/cleaner.go
@@ -1,6 +1,7 @@
 package imcache
 
 import (
+	"errors"
 	"sync"
 	"time"
 )
@@ -24,14 +25,14 @@ type cleaner struct {
 	doneCh  chan struct{}
 }
 
-func (c *cleaner) start(r remover, interval time.Duration) {
+func (c *cleaner) start(r remover, interval time.Duration) error {
 	if interval <= 0 {
-		panic("imcache: interval must be greater than 0")
+		return errors.New("imcache: interval must be greater than 0")
 	}
 	c.mu.Lock()
 	if c.running {
 		c.mu.Unlock()
-		return
+		return errors.New("imcache: cleaner already running")
 	}
 	c.running = true
 	c.stopCh = make(chan struct{})
@@ -50,6 +51,7 @@ func (c *cleaner) start(r remover, interval time.Duration) {
 			}
 		}
 	}()
+	return nil
 }
 
 func (c *cleaner) stop() {


### PR DESCRIPTION
This PR changes the `Cleaner` to return an err instead of panic when starting.

`StartCleaner` method returns an error if a cleaner's interval is equal to or less than 0 or if the `Cleaner` is already running.
