### PR TITLE
Export concrete types

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -12,58 +12,6 @@ import (
 	"time"
 )
 
-// Imcache is the interface that wraps cache operations.
-type Imcache[K comparable, V any] interface {
-	// Get returns the value for the given key.
-	Get(key K) (v V, present bool)
-	// Set sets the value for the given key.
-	// If the entry already exists, it is replaced.
-	//
-	// If you don't want to replace an existing entry, use the GetOrSet method instead.
-	// If you don't want to add a new entry if it doesn't exist, use the Replace method instead.
-	Set(key K, val V, exp Expiration)
-	// GetOrSet returns the value for the given key and true if it exists,
-	// otherwise it sets the value for the given key and returns the set value and false.
-	GetOrSet(key K, val V, exp Expiration) (v V, present bool)
-	// Replace replaces the value for the given key.
-	// It returns true if the value is present and replaced, otherwise it returns false.
-	//
-	// If you want to add or replace an entry, use the Set method instead.
-	Replace(key K, val V, exp Expiration) (present bool)
-	// ReplaceWithFunc replaces the value for the given key
-	// with the result of the given function that takes the old value as an argument.
-	// It returns true if the value is present and replaced, otherwise it returns false.
-	//
-	// If you want to replace the value with a new value not depending on the old value,
-	// use the Replace method instead.
-	ReplaceWithFunc(key K, f func(old V) (new V), exp Expiration) (present bool)
-	// Remove removes the cache entry for the given key.
-	//
-	// It returns true if the entry is present and removed,
-	// otherwise it returns false.
-	Remove(key K) (present bool)
-	// RemoveAll removes all entries.
-	RemoveAll()
-	// RemoveStale removes all expired entries.
-	RemoveStale()
-	// GetAll returns a copy of all entries in the cache.
-	GetAll() map[K]V
-	// Len returns the number of entries in the cache.
-	Len() int
-	// StartCleaner starts a cleaner that periodically removes expired entries.
-	// A cleaner runs in a separate goroutine.
-	// It's a NOP method if the cleaner is already running.
-	// It returns an error if the cleaner is already running
-	// or if the interval is less than or equal to zero.
-	//
-	// The cleaner can be stopped by calling StopCleaner method.
-	StartCleaner(interval time.Duration) error
-	// StopCleaner stops the cleaner.
-	// It is a blocking method that waits for the cleaner to stop.
-	// It's a NOP method if the cleaner is not running.
-	StopCleaner()
-}
-
 // New returns a new Cache instance.
 //
 // By default a returned Cache has no default expiration,
@@ -82,7 +30,6 @@ func New[K comparable, V any](opts ...Option[K, V]) *Cache[K, V] {
 }
 
 // Cache is a non-sharded in-memory cache.
-// It is a non-sharded cache.
 //
 // By default it has no default expiration,
 // no default sliding expiration and no eviction callback.
@@ -628,4 +575,56 @@ func (s *Sharded[K, V]) StartCleaner(interval time.Duration) error {
 // It's a NOP method if the cleaner is not running.
 func (s *Sharded[K, V]) StopCleaner() {
 	s.cleaner.stop()
+}
+
+// Imcache is the interface that wraps cache operations.
+type Imcache[K comparable, V any] interface {
+	// Get returns the value for the given key.
+	Get(key K) (v V, present bool)
+	// Set sets the value for the given key.
+	// If the entry already exists, it is replaced.
+	//
+	// If you don't want to replace an existing entry, use the GetOrSet method instead.
+	// If you don't want to add a new entry if it doesn't exist, use the Replace method instead.
+	Set(key K, val V, exp Expiration)
+	// GetOrSet returns the value for the given key and true if it exists,
+	// otherwise it sets the value for the given key and returns the set value and false.
+	GetOrSet(key K, val V, exp Expiration) (v V, present bool)
+	// Replace replaces the value for the given key.
+	// It returns true if the value is present and replaced, otherwise it returns false.
+	//
+	// If you want to add or replace an entry, use the Set method instead.
+	Replace(key K, val V, exp Expiration) (present bool)
+	// ReplaceWithFunc replaces the value for the given key
+	// with the result of the given function that takes the old value as an argument.
+	// It returns true if the value is present and replaced, otherwise it returns false.
+	//
+	// If you want to replace the value with a new value not depending on the old value,
+	// use the Replace method instead.
+	ReplaceWithFunc(key K, f func(old V) (new V), exp Expiration) (present bool)
+	// Remove removes the cache entry for the given key.
+	//
+	// It returns true if the entry is present and removed,
+	// otherwise it returns false.
+	Remove(key K) (present bool)
+	// RemoveAll removes all entries.
+	RemoveAll()
+	// RemoveStale removes all expired entries.
+	RemoveStale()
+	// GetAll returns a copy of all entries in the cache.
+	GetAll() map[K]V
+	// Len returns the number of entries in the cache.
+	Len() int
+	// StartCleaner starts a cleaner that periodically removes expired entries.
+	// A cleaner runs in a separate goroutine.
+	// It's a NOP method if the cleaner is already running.
+	// It returns an error if the cleaner is already running
+	// or if the interval is less than or equal to zero.
+	//
+	// The cleaner can be stopped by calling StopCleaner method.
+	StartCleaner(interval time.Duration) error
+	// StopCleaner stops the cleaner.
+	// It is a blocking method that waits for the cleaner to stop.
+	// It's a NOP method if the cleaner is not running.
+	StopCleaner()
 }

--- a/cache.go
+++ b/cache.go
@@ -2,9 +2,9 @@
 // It supports expiration, sliding expiration, eviction callbacks and sharding.
 // It's safe for concurrent use by multiple goroutines.
 //
-// The New function creates a new Cache instance.
+// The New function creates a new in-memory non-sharded cache instance.
 //
-// The NewSharded function creates a new sharded Cache instance.
+// The NewSharded function creates a new in-memory sharded cache instance.
 package imcache
 
 import (
@@ -12,29 +12,21 @@ import (
 	"time"
 )
 
-// Cache is the interface that wraps cache operations.
-type Cache[K comparable, V any] interface {
+// Imcache is the interface that wraps cache operations.
+type Imcache[K comparable, V any] interface {
 	// Get returns the value for the given key.
-	//
-	// If it encounters an expired entry, the expired entry is evicted.
 	Get(key K) (v V, present bool)
 	// Set sets the value for the given key.
 	// If the entry already exists, it is replaced.
-	//
-	// If it encounters an expired entry, it is evicted and a new entry is added.
 	//
 	// If you don't want to replace an existing entry, use the GetOrSet method instead.
 	// If you don't want to add a new entry if it doesn't exist, use the Replace method instead.
 	Set(key K, val V, exp Expiration)
 	// GetOrSet returns the value for the given key and true if it exists,
 	// otherwise it sets the value for the given key and returns the set value and false.
-	//
-	// If it encounters an expired entry, the expired entry is evicted.
 	GetOrSet(key K, val V, exp Expiration) (v V, present bool)
 	// Replace replaces the value for the given key.
 	// It returns true if the value is present and replaced, otherwise it returns false.
-	//
-	// If it encounters an expired entry, the expired entry is evicted.
 	//
 	// If you want to add or replace an entry, use the Set method instead.
 	Replace(key K, val V, exp Expiration) (present bool)
@@ -42,43 +34,19 @@ type Cache[K comparable, V any] interface {
 	// with the result of the given function that takes the old value as an argument.
 	// It returns true if the value is present and replaced, otherwise it returns false.
 	//
-	// If it encounters an expired entry, the expired entry is evicted.
-	//
 	// If you want to replace the value with a new value not depending on the old value,
 	// use the Replace method instead.
-	//
-	// imcache provides the Increment and Decrement functions that can be used as f
-	// to increment or decrement the old value.
-	//
-	// Example:
-	//	c := imcache.New[string, int32]()
-	//	c.Set("foo", 997, imcache.WithNoExpiration())
-	//	_ = c.ReplaceWithFunc("foo", imcache.Increment[int32], imcache.WithNoExpiration())
 	ReplaceWithFunc(key K, f func(old V) (new V), exp Expiration) (present bool)
 	// Remove removes the cache entry for the given key.
 	//
 	// It returns true if the entry is present and removed,
 	// otherwise it returns false.
-	//
-	// If it encounters an expired entry, the expired entry is evicted.
-	// It results in calling the eviction callback with EvictionReasonExpired,
-	// not EvictionReasonRemoved. If entry is expired, it returns false.
 	Remove(key K) (present bool)
 	// RemoveAll removes all entries.
-	//
-	// If eviction callback is set, it is called for each removed entry.
-	//
-	// If it encounters an expired entry, the expired entry is evicted.
-	// It results in calling the eviction callback with EvictionReasonExpired,
-	// not EvictionReasonRemoved.
 	RemoveAll()
 	// RemoveStale removes all expired entries.
-	//
-	// If eviction callback is set, it is called for each removed entry.
 	RemoveStale()
 	// GetAll returns a copy of all entries in the cache.
-	//
-	// If it encounters an expired entry, the expired entry is evicted.
 	GetAll() map[K]V
 	// Len returns the number of entries in the cache.
 	Len() int
@@ -96,17 +64,13 @@ type Cache[K comparable, V any] interface {
 	StopCleaner()
 }
 
-// New returns a new non-sharded Cache instance.
+// New returns a new Cache instance.
 //
 // By default a returned Cache has no default expiration,
 // no default sliding expiration and no eviction callback.
 // Option(s) can be used to customize the returned Cache.
-func New[K comparable, V any](opts ...Option[K, V]) Cache[K, V] {
-	return newShard(opts...)
-}
-
-func newShard[K comparable, V any](opts ...Option[K, V]) *shard[K, V] {
-	s := &shard[K, V]{
+func New[K comparable, V any](opts ...Option[K, V]) *Cache[K, V] {
+	s := &Cache[K, V]{
 		m:          make(map[K]entry[V]),
 		defaultExp: -1,
 		cleaner:    newCleaner(),
@@ -117,8 +81,23 @@ func newShard[K comparable, V any](opts ...Option[K, V]) *shard[K, V] {
 	return s
 }
 
-// shard is a non-sharded cache.
-type shard[K comparable, V any] struct {
+// Cache is a non-sharded in-memory cache.
+// It is a non-sharded cache.
+//
+// By default it has no default expiration,
+// no default sliding expiration and no eviction callback.
+// It implements the Imcache interface.
+//
+// The zero value Cache is ready to use.
+//
+// If you want to configure a Cache, use the New function
+// and provide proper Option(s).
+//
+//	c := imcache.New(
+//		imcache.WithDefaultExpirationOption[string, interface{}](time.Second),
+//		imcache.WithEvictionCallbackOption(LogEvictedEntry),
+//	)
+type Cache[K comparable, V any] struct {
 	mu sync.Mutex
 	m  map[K]entry[V]
 
@@ -130,7 +109,18 @@ type shard[K comparable, V any] struct {
 	cleaner *cleaner
 }
 
-func (s *shard[K, V]) Get(key K) (V, bool) {
+// init initializes the Cache.
+// It is not a concurrently-safe method.
+func (s *Cache[K, V]) init() {
+	if s.m == nil {
+		s.m = make(map[K]entry[V])
+	}
+}
+
+// Get returns the value for the given key.
+//
+// If it encounters an expired entry, the expired entry is evicted.
+func (s *Cache[K, V]) Get(key K) (V, bool) {
 	now := time.Now()
 	var empty V
 	s.mu.Lock()
@@ -155,12 +145,21 @@ func (s *shard[K, V]) Get(key K) (V, bool) {
 	return entry.val, true
 }
 
-func (s *shard[K, V]) Set(key K, val V, exp Expiration) {
+// Set sets the value for the given key.
+// If the entry already exists, it is replaced.
+//
+// If it encounters an expired entry, it is evicted and a new entry is added.
+//
+// If you don't want to replace an existing entry, use the GetOrSet method instead.
+// If you don't want to add a new entry if it doesn't exist, use the Replace method instead.
+func (s *Cache[K, V]) Set(key K, val V, exp Expiration) {
 	now := time.Now()
 	entry := entry[V]{val: val}
 	exp.apply(&entry.exp)
 	entry.SetDefault(now, s.defaultExp, s.sliding)
 	s.mu.Lock()
+	// Make sure that the shard is initialized.
+	s.init()
 	current, ok := s.m[key]
 	s.m[key] = entry
 	s.mu.Unlock()
@@ -173,12 +172,18 @@ func (s *shard[K, V]) Set(key K, val V, exp Expiration) {
 	}
 }
 
-func (s *shard[K, V]) GetOrSet(key K, val V, exp Expiration) (V, bool) {
+// GetOrSet returns the value for the given key and true if it exists,
+// otherwise it sets the value for the given key and returns the set value and false.
+//
+// If it encounters an expired entry, the expired entry is evicted.
+func (s *Cache[K, V]) GetOrSet(key K, val V, exp Expiration) (V, bool) {
 	now := time.Now()
 	entry := entry[V]{val: val}
 	exp.apply(&entry.exp)
 	entry.SetDefault(now, s.defaultExp, s.sliding)
 	s.mu.Lock()
+	// Make sure that the shard is initialized.
+	s.init()
 	current, ok := s.m[key]
 	if ok && !current.HasExpired(now) {
 		s.mu.Unlock()
@@ -192,7 +197,13 @@ func (s *shard[K, V]) GetOrSet(key K, val V, exp Expiration) (V, bool) {
 	return entry.val, false
 }
 
-func (s *shard[K, V]) Replace(key K, val V, exp Expiration) bool {
+// Replace replaces the value for the given key.
+// It returns true if the value is present and replaced, otherwise it returns false.
+//
+// If it encounters an expired entry, the expired entry is evicted.
+//
+// If you want to add or replace an entry, use the Set method instead.
+func (s *Cache[K, V]) Replace(key K, val V, exp Expiration) bool {
 	now := time.Now()
 	entry := entry[V]{val: val}
 	exp.apply(&entry.exp)
@@ -219,7 +230,24 @@ func (s *shard[K, V]) Replace(key K, val V, exp Expiration) bool {
 	return true
 }
 
-func (s *shard[K, V]) ReplaceWithFunc(key K, f func(V) V, exp Expiration) bool {
+// ReplaceWithFunc replaces the value for the given key
+// with the result of the given function that takes the old value as an argument.
+// It returns true if the value is present and replaced, otherwise it returns false.
+//
+// If it encounters an expired entry, the expired entry is evicted.
+//
+// If you want to replace the value with a new value not depending on the old value,
+// use the Replace method instead.
+//
+// imcache provides the Increment and Decrement functions that can be used as f
+// to increment or decrement the old numeric type value.
+//
+// Example:
+//
+//	var c imcache.Cache[string, int32]
+//	c.Set("foo", 997, imcache.WithNoExpiration())
+//	_ = c.ReplaceWithFunc("foo", imcache.Increment[int32], imcache.WithNoExpiration())
+func (s *Cache[K, V]) ReplaceWithFunc(key K, f func(V) V, exp Expiration) bool {
 	now := time.Now()
 	s.mu.Lock()
 	current, ok := s.m[key]
@@ -246,7 +274,15 @@ func (s *shard[K, V]) ReplaceWithFunc(key K, f func(V) V, exp Expiration) bool {
 	return true
 }
 
-func (s *shard[K, V]) Remove(key K) bool {
+// Remove removes the cache entry for the given key.
+//
+// It returns true if the entry is present and removed,
+// otherwise it returns false.
+//
+// If it encounters an expired entry, the expired entry is evicted.
+// It results in calling the eviction callback with EvictionReasonExpired,
+// not EvictionReasonRemoved. If entry is expired, it returns false.
+func (s *Cache[K, V]) Remove(key K) bool {
 	now := time.Now()
 	s.mu.Lock()
 	entry, ok := s.m[key]
@@ -268,7 +304,7 @@ func (s *shard[K, V]) Remove(key K) bool {
 	return true
 }
 
-func (s *shard[K, V]) removeAll(now time.Time) {
+func (s *Cache[K, V]) removeAll(now time.Time) {
 	s.mu.Lock()
 	removed := s.m
 	s.m = make(map[K]entry[V])
@@ -284,11 +320,18 @@ func (s *shard[K, V]) removeAll(now time.Time) {
 	}
 }
 
-func (s *shard[K, V]) RemoveAll() {
+// RemoveAll removes all entries.
+//
+// If an eviction callback is set, it is called for each removed entry.
+//
+// If it encounters an expired entry, the expired entry is evicted.
+// It results in calling the eviction callback with EvictionReasonExpired,
+// not EvictionReasonRemoved.
+func (s *Cache[K, V]) RemoveAll() {
 	s.removeAll(time.Now())
 }
 
-func (s *shard[K, V]) removeStale(now time.Time) {
+func (s *Cache[K, V]) removeStale(now time.Time) {
 	s.mu.Lock()
 	// To avoid copying the expired entries if there's no eviction callback.
 	if s.onEviction == nil {
@@ -313,7 +356,10 @@ func (s *shard[K, V]) removeStale(now time.Time) {
 	}
 }
 
-func (s *shard[K, V]) RemoveStale() {
+// RemoveStale removes all expired entries.
+//
+// If an eviction callback is set, it is called for each removed entry.
+func (s *Cache[K, V]) RemoveStale() {
 	s.removeStale(time.Now())
 }
 
@@ -322,7 +368,7 @@ type kv[K comparable, V any] struct {
 	val V
 }
 
-func (s *shard[K, V]) getAll(now time.Time) map[K]V {
+func (s *Cache[K, V]) getAll(now time.Time) map[K]V {
 	s.mu.Lock()
 	// To avoid copying the expired entries if there's no eviction callback.
 	if s.onEviction == nil {
@@ -362,44 +408,57 @@ func (s *shard[K, V]) getAll(now time.Time) map[K]V {
 	return m
 }
 
-func (s *shard[K, V]) GetAll() map[K]V {
+// GetAll returns a copy of all entries in the cache.
+//
+// If it encounters an expired entry, the expired entry is evicted.
+func (s *Cache[K, V]) GetAll() map[K]V {
 	return s.getAll(time.Now())
 }
 
-func (s *shard[K, V]) Len() int {
+// Len returns the number of entries in the cache.
+func (s *Cache[K, V]) Len() int {
 	s.mu.Lock()
 	n := len(s.m)
 	s.mu.Unlock()
 	return n
 }
 
-func (s *shard[K, V]) StartCleaner(interval time.Duration) error {
+// StartCleaner starts a cleaner that periodically removes expired entries.
+// A cleaner runs in a separate goroutine.
+// It's a NOP method if the cleaner is already running.
+// It returns an error if the cleaner is already running
+// or if the interval is less than or equal to zero.
+//
+// The cleaner can be stopped by calling StopCleaner method.
+func (s *Cache[K, V]) StartCleaner(interval time.Duration) error {
 	return s.cleaner.start(s, interval)
 }
 
-func (s *shard[K, V]) StopCleaner() {
+// StopCleaner stops the cleaner.
+// It is a blocking method that waits for the cleaner to stop.
+// It's a NOP method if the cleaner is not running.
+func (s *Cache[K, V]) StopCleaner() {
 	s.cleaner.stop()
 }
 
-// NewSharded returns a new Cache instance consisting of n shards
-// and sharded by the given Hasher64.
+// NewSharded returns a new Sharded instance.
 // It panics if n is not greater than 0 or hasher is nil.
 //
-// By default a returned Cache has no default expiration,
+// By default a returned Sharded has no default expiration,
 // no default sliding expiration and no eviction callback.
-// Option(s) can be used to customize the returned Cache.
-func NewSharded[K comparable, V any](n int, hasher Hasher64[K], opts ...Option[K, V]) Cache[K, V] {
+// Option(s) can be used to customize the returned Sharded.
+func NewSharded[K comparable, V any](n int, hasher Hasher64[K], opts ...Option[K, V]) *Sharded[K, V] {
 	if n <= 0 {
 		panic("imcache: number of shards must be greater than 0")
 	}
 	if hasher == nil {
 		panic("imcache: hasher must be not nil")
 	}
-	shards := make([]*shard[K, V], n)
+	shards := make([]*Cache[K, V], n)
 	for i := 0; i < n; i++ {
-		shards[i] = newShard(opts...)
+		shards[i] = New(opts...)
 	}
-	return &sharded[K, V]{
+	return &Sharded[K, V]{
 		shards:  shards,
 		hasher:  hasher,
 		mask:    uint64(n - 1),
@@ -407,58 +466,126 @@ func NewSharded[K comparable, V any](n int, hasher Hasher64[K], opts ...Option[K
 	}
 }
 
-// sharded is a sharded cache.
-type sharded[K comparable, V any] struct {
-	shards []*shard[K, V]
+// Sharded is a sharded in-memory cache.
+// It is a cache consisting of n shards
+// and sharded by the given Hasher64.
+//
+// By default it has no default expiration,
+// no default sliding expiration and no eviction callback.
+// It implements the Imcache interface.
+//
+// The zero value Sharded is NOT ready to use.
+// The NewSharded function must be used to create a new Sharded.
+type Sharded[K comparable, V any] struct {
+	shards []*Cache[K, V]
 	hasher Hasher64[K]
 	mask   uint64
 
 	cleaner *cleaner
 }
 
-func (s *sharded[K, V]) shard(key K) Cache[K, V] {
+// shard returns the shard for the given key.
+func (s *Sharded[K, V]) shard(key K) *Cache[K, V] {
 	return s.shards[s.hasher.Sum64(key)&s.mask]
 }
 
-func (s *sharded[K, V]) Get(key K) (V, bool) {
+// Get returns the value for the given key.
+//
+// If it encounters an expired entry, the expired entry is evicted.
+func (s *Sharded[K, V]) Get(key K) (V, bool) {
 	return s.shard(key).Get(key)
 }
 
-func (s *sharded[K, V]) Set(key K, val V, exp Expiration) {
+// Set sets the value for the given key.
+// If the entry already exists, it is replaced.
+//
+// If it encounters an expired entry, it is evicted and a new entry is added.
+//
+// If you don't want to replace an existing entry, use the GetOrSet method instead.
+// If you don't want to add a new entry if it doesn't exist, use the Replace method instead.
+func (s *Sharded[K, V]) Set(key K, val V, exp Expiration) {
 	s.shard(key).Set(key, val, exp)
 }
 
-func (s *sharded[K, V]) GetOrSet(key K, val V, exp Expiration) (v V, present bool) {
+// GetOrSet returns the value for the given key and true if it exists,
+// otherwise it sets the value for the given key and returns the set value and false.
+//
+// If it encounters an expired entry, the expired entry is evicted.
+func (s *Sharded[K, V]) GetOrSet(key K, val V, exp Expiration) (v V, present bool) {
 	return s.shard(key).GetOrSet(key, val, exp)
 }
 
-func (s *sharded[K, V]) Replace(key K, val V, exp Expiration) bool {
+// Replace replaces the value for the given key.
+// It returns true if the value is present and replaced, otherwise it returns false.
+//
+// If it encounters an expired entry, the expired entry is evicted.
+//
+// If you want to add or replace an entry, use the Set method instead.
+func (s *Sharded[K, V]) Replace(key K, val V, exp Expiration) bool {
 	return s.shard(key).Replace(key, val, exp)
 }
 
-func (s *sharded[K, V]) ReplaceWithFunc(key K, fn func(V) V, exp Expiration) bool {
+// ReplaceWithFunc replaces the value for the given key
+// with the result of the given function that takes the old value as an argument.
+// It returns true if the value is present and replaced, otherwise it returns false.
+//
+// If it encounters an expired entry, the expired entry is evicted.
+//
+// If you want to replace the value with a new value not depending on the old value,
+// use the Replace method instead.
+//
+// imcache provides the Increment and Decrement functions that can be used as f
+// to increment or decrement the old numeric type value.
+//
+// Example:
+//
+//	c := imcache.NewSharded[string, int32](4, imcache.DefaultStringHasher64{})
+//	c.Set("foo", 997, imcache.WithNoExpiration())
+//	_ = c.ReplaceWithFunc("foo", imcache.Increment[int32], imcache.WithNoExpiration())
+func (s *Sharded[K, V]) ReplaceWithFunc(key K, fn func(V) V, exp Expiration) bool {
 	return s.shard(key).ReplaceWithFunc(key, fn, exp)
 }
 
-func (s *sharded[K, V]) Remove(key K) bool {
+// Remove removes the cache entry for the given key.
+//
+// It returns true if the entry is present and removed,
+// otherwise it returns false.
+//
+// If it encounters an expired entry, the expired entry is evicted.
+// It results in calling the eviction callback with EvictionReasonExpired,
+// not EvictionReasonRemoved. If entry is expired, it returns false.
+func (s *Sharded[K, V]) Remove(key K) bool {
 	return s.shard(key).Remove(key)
 }
 
-func (s *sharded[K, V]) RemoveAll() {
+// RemoveAll removes all entries.
+//
+// If an eviction callback is set, it is called for each removed entry.
+//
+// If it encounters an expired entry, the expired entry is evicted.
+// It results in calling the eviction callback with EvictionReasonExpired,
+// not EvictionReasonRemoved.
+func (s *Sharded[K, V]) RemoveAll() {
 	now := time.Now()
 	for _, shard := range s.shards {
 		shard.removeAll(now)
 	}
 }
 
-func (s *sharded[K, V]) RemoveStale() {
+// RemoveStale removes all expired entries.
+//
+// If an eviction callback is set, it is called for each removed entry.
+func (s *Sharded[K, V]) RemoveStale() {
 	now := time.Now()
 	for _, shard := range s.shards {
 		shard.removeStale(now)
 	}
 }
 
-func (s *sharded[K, V]) GetAll() map[K]V {
+// GetAll returns a copy of all entries in the cache.
+//
+// If it encounters an expired entry, the expired entry is evicted.
+func (s *Sharded[K, V]) GetAll() map[K]V {
 	now := time.Now()
 	var n int
 	ms := make([]map[K]V, 0, len(s.shards))
@@ -476,7 +603,8 @@ func (s *sharded[K, V]) GetAll() map[K]V {
 	return all
 }
 
-func (s *sharded[K, V]) Len() int {
+// Len returns the number of entries in the cache.
+func (s *Sharded[K, V]) Len() int {
 	var n int
 	for _, shard := range s.shards {
 		n += shard.Len()
@@ -484,10 +612,20 @@ func (s *sharded[K, V]) Len() int {
 	return n
 }
 
-func (s *sharded[K, V]) StartCleaner(interval time.Duration) error {
+// StartCleaner starts a cleaner that periodically removes expired entries.
+// A cleaner runs in a separate goroutine.
+// It's a NOP method if the cleaner is already running.
+// It returns an error if the cleaner is already running
+// or if the interval is less than or equal to zero.
+//
+// The cleaner can be stopped by calling StopCleaner method.
+func (s *Sharded[K, V]) StartCleaner(interval time.Duration) error {
 	return s.cleaner.start(s, interval)
 }
 
-func (s *sharded[K, V]) StopCleaner() {
+// StopCleaner stops the cleaner.
+// It is a blocking method that waits for the cleaner to stop.
+// It's a NOP method if the cleaner is not running.
+func (s *Sharded[K, V]) StopCleaner() {
 	s.cleaner.stop()
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -13,17 +13,17 @@ func init() {
 	rand.Seed(time.Now().UnixNano())
 }
 
-func TestCache_Get(t *testing.T) {
+func TestImcache_Get(t *testing.T) {
 	tests := []struct {
 		name string
-		c    func() Cache[string, string]
+		c    func() Imcache[string, string]
 		key  string
 		want string
 		ok   bool
 	}{
 		{
 			name: "success",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := New[string, string]()
 				c.Set("foo", "bar", WithNoExpiration())
 				return c
@@ -34,7 +34,7 @@ func TestCache_Get(t *testing.T) {
 		},
 		{
 			name: "not found",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := New[string, string]()
 				return c
 			},
@@ -42,7 +42,7 @@ func TestCache_Get(t *testing.T) {
 		},
 		{
 			name: "entry expired",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := New[string, string]()
 				c.Set("foo", "bar", WithExpiration(time.Nanosecond))
 				<-time.After(time.Nanosecond)
@@ -52,7 +52,7 @@ func TestCache_Get(t *testing.T) {
 		},
 		{
 			name: "success - sharded",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := NewSharded[string, string](2, DefaultStringHasher64{})
 				c.Set("foo", "bar", WithNoExpiration())
 				return c
@@ -63,7 +63,7 @@ func TestCache_Get(t *testing.T) {
 		},
 		{
 			name: "not found - sharded",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := NewSharded[string, string](4, DefaultStringHasher64{})
 				return c
 			},
@@ -71,7 +71,7 @@ func TestCache_Get(t *testing.T) {
 		},
 		{
 			name: "entry expired - sharded",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := NewSharded[string, string](8, DefaultStringHasher64{})
 				c.Set("foo", "bar", WithExpiration(time.Nanosecond))
 				<-time.After(time.Nanosecond)
@@ -95,10 +95,10 @@ func TestCache_Get(t *testing.T) {
 	}
 }
 
-func TestCache_Get_SlidingExpiration(t *testing.T) {
+func TestImcache_Get_SlidingExpiration(t *testing.T) {
 	tests := []struct {
 		name string
-		c    Cache[string, string]
+		c    Imcache[string, string]
 	}{
 		{
 			name: "not sharded",
@@ -130,16 +130,16 @@ func TestCache_Get_SlidingExpiration(t *testing.T) {
 	}
 }
 
-func TestCache_Set(t *testing.T) {
+func TestImcache_Set(t *testing.T) {
 	tests := []struct {
 		name string
-		c    func() Cache[string, string]
+		c    func() Imcache[string, string]
 		key  string
 		val  string
 	}{
 		{
 			name: "add new entry",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := New[string, string]()
 				return c
 			},
@@ -148,7 +148,7 @@ func TestCache_Set(t *testing.T) {
 		},
 		{
 			name: "replace existing entry",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := New[string, string]()
 				c.Set("foo", "foo", WithNoExpiration())
 				return c
@@ -158,7 +158,7 @@ func TestCache_Set(t *testing.T) {
 		},
 		{
 			name: "add new entry if old expired",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := New[string, string]()
 				c.Set("foo", "foo", WithExpiration(time.Nanosecond))
 				<-time.After(time.Nanosecond)
@@ -169,7 +169,7 @@ func TestCache_Set(t *testing.T) {
 		},
 		{
 			name: "add new entry - sharded",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := NewSharded[string, string](2, DefaultStringHasher64{})
 				return c
 			},
@@ -178,7 +178,7 @@ func TestCache_Set(t *testing.T) {
 		},
 		{
 			name: "replace existing entry - sharded",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := NewSharded[string, string](4, DefaultStringHasher64{})
 				c.Set("foo", "foo", WithNoExpiration())
 				return c
@@ -188,7 +188,7 @@ func TestCache_Set(t *testing.T) {
 		},
 		{
 			name: "add new entry if old expired - sharded",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := NewSharded[string, string](8, DefaultStringHasher64{})
 				c.Set("foo", "foo", WithExpiration(time.Nanosecond))
 				<-time.After(time.Nanosecond)
@@ -214,10 +214,10 @@ func TestCache_Set(t *testing.T) {
 	}
 }
 
-func TestCache_GetOrSet(t *testing.T) {
+func TestImcache_GetOrSet(t *testing.T) {
 	tests := []struct {
 		name    string
-		c       func() Cache[string, string]
+		c       func() Imcache[string, string]
 		key     string
 		val     string
 		want    string
@@ -225,7 +225,7 @@ func TestCache_GetOrSet(t *testing.T) {
 	}{
 		{
 			name: "add new entry",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := New[string, string]()
 				return c
 			},
@@ -235,7 +235,7 @@ func TestCache_GetOrSet(t *testing.T) {
 		},
 		{
 			name: "add new entry if old expired",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := New[string, string]()
 				c.Set("foo", "foo", WithExpiration(time.Nanosecond))
 				<-time.After(time.Nanosecond)
@@ -247,7 +247,7 @@ func TestCache_GetOrSet(t *testing.T) {
 		},
 		{
 			name: "get existing entry",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := New[string, string]()
 				c.Set("foo", "foo", WithNoExpiration())
 				return c
@@ -259,7 +259,7 @@ func TestCache_GetOrSet(t *testing.T) {
 		},
 		{
 			name: "add new entry - sharded",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := NewSharded[string, string](2, DefaultStringHasher64{})
 				return c
 			},
@@ -269,7 +269,7 @@ func TestCache_GetOrSet(t *testing.T) {
 		},
 		{
 			name: "add new entry if old expired - sharded",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := NewSharded[string, string](4, DefaultStringHasher64{})
 				c.Set("foo", "foo", WithExpiration(time.Nanosecond))
 				<-time.After(time.Nanosecond)
@@ -281,7 +281,7 @@ func TestCache_GetOrSet(t *testing.T) {
 		},
 		{
 			name: "get existing entry - sharded",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := NewSharded[string, string](8, DefaultStringHasher64{})
 				c.Set("foo", "foo", WithNoExpiration())
 				return c
@@ -307,17 +307,17 @@ func TestCache_GetOrSet(t *testing.T) {
 	}
 }
 
-func TestCache_Replace(t *testing.T) {
+func TestImcache_Replace(t *testing.T) {
 	tests := []struct {
 		name    string
-		c       func() Cache[string, string]
+		c       func() Imcache[string, string]
 		key     string
 		val     string
 		present bool
 	}{
 		{
 			name: "success",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := New[string, string]()
 				c.Set("foo", "foo", WithNoExpiration())
 				return c
@@ -328,7 +328,7 @@ func TestCache_Replace(t *testing.T) {
 		},
 		{
 			name: "entry expired",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := New[string, string]()
 				c.Set("foo", "foo", WithExpiration(time.Nanosecond))
 				<-time.After(time.Nanosecond)
@@ -339,7 +339,7 @@ func TestCache_Replace(t *testing.T) {
 		},
 		{
 			name: "entry doesn't exist",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := New[string, string]()
 				return c
 			},
@@ -348,7 +348,7 @@ func TestCache_Replace(t *testing.T) {
 		},
 		{
 			name: "success - sharded",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := NewSharded[string, string](2, DefaultStringHasher64{})
 				c.Set("foo", "foo", WithNoExpiration())
 				return c
@@ -359,7 +359,7 @@ func TestCache_Replace(t *testing.T) {
 		},
 		{
 			name: "entry expired - sharded",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := NewSharded[string, string](4, DefaultStringHasher64{})
 				c.Set("foo", "foo", WithExpiration(time.Nanosecond))
 				<-time.After(time.Nanosecond)
@@ -370,7 +370,7 @@ func TestCache_Replace(t *testing.T) {
 		},
 		{
 			name: "entry doesn't exist - sharded",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := NewSharded[string, string](8, DefaultStringHasher64{})
 				return c
 			},
@@ -399,10 +399,10 @@ func TestCache_Replace(t *testing.T) {
 	}
 }
 
-func TestCache_ReplaceWithFunc(t *testing.T) {
+func TestImcache_ReplaceWithFunc(t *testing.T) {
 	tests := []struct {
 		name    string
-		c       func() Cache[string, int32]
+		c       func() Imcache[string, int32]
 		key     string
 		f       func(int32) int32
 		want    bool
@@ -411,7 +411,7 @@ func TestCache_ReplaceWithFunc(t *testing.T) {
 	}{
 		{
 			name: "success",
-			c: func() Cache[string, int32] {
+			c: func() Imcache[string, int32] {
 				c := New[string, int32]()
 				c.Set("foo", 997, WithNoExpiration())
 				return c
@@ -424,7 +424,7 @@ func TestCache_ReplaceWithFunc(t *testing.T) {
 		},
 		{
 			name: "entry expired",
-			c: func() Cache[string, int32] {
+			c: func() Imcache[string, int32] {
 				c := New[string, int32]()
 				c.Set("foo", 997, WithExpiration(time.Nanosecond))
 				<-time.After(time.Nanosecond)
@@ -435,7 +435,7 @@ func TestCache_ReplaceWithFunc(t *testing.T) {
 		},
 		{
 			name: "entry doesn't exist",
-			c: func() Cache[string, int32] {
+			c: func() Imcache[string, int32] {
 				c := New[string, int32]()
 				return c
 			},
@@ -444,7 +444,7 @@ func TestCache_ReplaceWithFunc(t *testing.T) {
 		},
 		{
 			name: "success - sharded",
-			c: func() Cache[string, int32] {
+			c: func() Imcache[string, int32] {
 				c := NewSharded[string, int32](2, DefaultStringHasher64{})
 				c.Set("foo", 997, WithNoExpiration())
 				return c
@@ -457,7 +457,7 @@ func TestCache_ReplaceWithFunc(t *testing.T) {
 		},
 		{
 			name: "entry expired - sharded",
-			c: func() Cache[string, int32] {
+			c: func() Imcache[string, int32] {
 				c := NewSharded[string, int32](4, DefaultStringHasher64{})
 				c.Set("foo", 997, WithExpiration(time.Nanosecond))
 				<-time.After(time.Nanosecond)
@@ -468,7 +468,7 @@ func TestCache_ReplaceWithFunc(t *testing.T) {
 		},
 		{
 			name: "entry doesn't exist - sharded",
-			c: func() Cache[string, int32] {
+			c: func() Imcache[string, int32] {
 				c := NewSharded[string, int32](8, DefaultStringHasher64{})
 				return c
 			},
@@ -494,16 +494,16 @@ func TestCache_ReplaceWithFunc(t *testing.T) {
 	}
 }
 
-func TestCache_Remove(t *testing.T) {
+func TestImcache_Remove(t *testing.T) {
 	tests := []struct {
 		name    string
-		c       func() Cache[string, string]
+		c       func() Imcache[string, string]
 		key     string
 		present bool
 	}{
 		{
 			name: "success",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := New[string, string]()
 				c.Set("foo", "foo", WithNoExpiration())
 				return c
@@ -513,7 +513,7 @@ func TestCache_Remove(t *testing.T) {
 		},
 		{
 			name: "entry doesn't exist",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := New[string, string]()
 				c.Set("foo", "foo", WithNoExpiration())
 				return c
@@ -522,7 +522,7 @@ func TestCache_Remove(t *testing.T) {
 		},
 		{
 			name: "entry expired",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := New[string, string]()
 				c.Set("foo", "foo", WithExpiration(time.Nanosecond))
 				<-time.After(time.Nanosecond)
@@ -532,7 +532,7 @@ func TestCache_Remove(t *testing.T) {
 		},
 		{
 			name: "success - sharded",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := NewSharded[string, string](2, DefaultStringHasher64{})
 				c.Set("foo", "foo", WithExpirationDate(time.Now().Add(time.Minute)))
 				return c
@@ -542,7 +542,7 @@ func TestCache_Remove(t *testing.T) {
 		},
 		{
 			name: "entry doesn't exist - sharded",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := NewSharded[string, string](4, DefaultStringHasher64{})
 				c.Set("foo", "foo", WithNoExpiration())
 				return c
@@ -551,7 +551,7 @@ func TestCache_Remove(t *testing.T) {
 		},
 		{
 			name: "entry expired - sharded",
-			c: func() Cache[string, string] {
+			c: func() Imcache[string, string] {
 				c := NewSharded[string, string](8, DefaultStringHasher64{})
 				c.Set("foo", "foo", WithExpirationDate(time.Now().Add(time.Nanosecond)))
 				<-time.After(time.Nanosecond)
@@ -574,10 +574,10 @@ func TestCache_Remove(t *testing.T) {
 	}
 }
 
-func TestCache_RemoveAll(t *testing.T) {
+func TestImcache_RemoveAll(t *testing.T) {
 	tests := []struct {
 		name string
-		c    Cache[string, string]
+		c    Imcache[string, string]
 	}{
 		{
 			name: "not sharded",
@@ -606,10 +606,10 @@ func TestCache_RemoveAll(t *testing.T) {
 	}
 }
 
-func TestCache_RemoveStale(t *testing.T) {
+func TestImcache_RemoveStale(t *testing.T) {
 	tests := []struct {
 		name string
-		c    Cache[string, string]
+		c    Imcache[string, string]
 	}{
 		{
 			name: "not sharded",
@@ -638,10 +638,10 @@ func TestCache_RemoveStale(t *testing.T) {
 	}
 }
 
-func TestCache_GetAll(t *testing.T) {
+func TestImcache_GetAll(t *testing.T) {
 	tests := []struct {
 		name string
-		c    Cache[string, string]
+		c    Imcache[string, string]
 	}{
 		{
 			name: "not sharded",
@@ -672,10 +672,10 @@ func TestCache_GetAll(t *testing.T) {
 	}
 }
 
-func TestCache_GetAll_SlidingExpiration(t *testing.T) {
+func TestImcache_GetAll_SlidingExpiration(t *testing.T) {
 	tests := []struct {
 		name string
-		c    Cache[string, string]
+		c    Imcache[string, string]
 	}{
 		{
 			name: "not sharded",
@@ -713,10 +713,10 @@ func TestCache_GetAll_SlidingExpiration(t *testing.T) {
 	}
 }
 
-func TestCache_Len(t *testing.T) {
+func TestImcache_Len(t *testing.T) {
 	tests := []struct {
 		name string
-		c    Cache[string, int]
+		c    Imcache[string, int]
 	}{
 		{
 			name: "not sharded",
@@ -742,10 +742,10 @@ func TestCache_Len(t *testing.T) {
 	}
 }
 
-func TestCache_DefaultExpiration(t *testing.T) {
+func TestImcache_DefaultExpiration(t *testing.T) {
 	tests := []struct {
 		name string
-		c    Cache[string, string]
+		c    Imcache[string, string]
 	}{
 		{
 			name: "not sharded",
@@ -769,10 +769,10 @@ func TestCache_DefaultExpiration(t *testing.T) {
 	}
 }
 
-func TestCache_DefaultSlidingExpiration(t *testing.T) {
+func TestImcache_DefaultSlidingExpiration(t *testing.T) {
 	tests := []struct {
 		name string
-		c    Cache[string, string]
+		c    Imcache[string, string]
 	}{
 		{
 			name: "not sharded",
@@ -842,12 +842,12 @@ func (m *evictionCallbackMock) Reset() {
 	m.calls = nil
 }
 
-func TestCache_Get_EvictionCallback(t *testing.T) {
+func TestImcache_Get_EvictionCallback(t *testing.T) {
 	evictioncMock := &evictionCallbackMock{}
 
 	tests := []struct {
 		name string
-		c    Cache[string, interface{}]
+		c    Imcache[string, interface{}]
 	}{
 		{
 			name: "not sharded",
@@ -875,12 +875,12 @@ func TestCache_Get_EvictionCallback(t *testing.T) {
 	}
 }
 
-func TestCache_Set_EvictionCallback(t *testing.T) {
+func TestImcache_Set_EvictionCallback(t *testing.T) {
 	evictioncMock := &evictionCallbackMock{}
 
 	tests := []struct {
 		name string
-		c    Cache[string, interface{}]
+		c    Imcache[string, interface{}]
 	}{
 		{
 			name: "not sharded",
@@ -911,12 +911,12 @@ func TestCache_Set_EvictionCallback(t *testing.T) {
 	}
 }
 
-func TestCache_GetOrSet_EvictionCallback(t *testing.T) {
+func TestImcache_GetOrSet_EvictionCallback(t *testing.T) {
 	evictioncMock := &evictionCallbackMock{}
 
 	tests := []struct {
 		name string
-		c    Cache[string, interface{}]
+		c    Imcache[string, interface{}]
 	}{
 		{
 			name: "not sharded",
@@ -946,12 +946,12 @@ func TestCache_GetOrSet_EvictionCallback(t *testing.T) {
 	}
 }
 
-func TestCache_Replace_EvictionCallback(t *testing.T) {
+func TestImcache_Replace_EvictionCallback(t *testing.T) {
 	evictioncMock := &evictionCallbackMock{}
 
 	tests := []struct {
 		name string
-		c    Cache[string, interface{}]
+		c    Imcache[string, interface{}]
 	}{
 		{
 			name: "not sharded",
@@ -986,12 +986,12 @@ func TestCache_Replace_EvictionCallback(t *testing.T) {
 	}
 }
 
-func TestCache_ReplaceWithFunc_EvictionCallback(t *testing.T) {
+func TestImcache_ReplaceWithFunc_EvictionCallback(t *testing.T) {
 	evictioncMock := &evictionCallbackMock{}
 
 	tests := []struct {
 		name string
-		c    Cache[string, interface{}]
+		c    Imcache[string, interface{}]
 	}{
 		{
 			name: "not sharded",
@@ -1026,12 +1026,12 @@ func TestCache_ReplaceWithFunc_EvictionCallback(t *testing.T) {
 	}
 }
 
-func TestCache_Remove_EvictionCallback(t *testing.T) {
+func TestImcache_Remove_EvictionCallback(t *testing.T) {
 	evictioncMock := &evictionCallbackMock{}
 
 	tests := []struct {
 		name string
-		c    Cache[string, interface{}]
+		c    Imcache[string, interface{}]
 	}{
 		{
 			name: "not sharded",
@@ -1066,12 +1066,12 @@ func TestCache_Remove_EvictionCallback(t *testing.T) {
 	}
 }
 
-func TestCache_RemoveAll_EvictionCallback(t *testing.T) {
+func TestImcache_RemoveAll_EvictionCallback(t *testing.T) {
 	evictioncMock := &evictionCallbackMock{}
 
 	tests := []struct {
 		name string
-		c    Cache[string, interface{}]
+		c    Imcache[string, interface{}]
 	}{
 		{
 			name: "not sharded",
@@ -1101,12 +1101,12 @@ func TestCache_RemoveAll_EvictionCallback(t *testing.T) {
 	}
 }
 
-func TestCache_RemoveStale_EvictionCallback(t *testing.T) {
+func TestImcache_RemoveStale_EvictionCallback(t *testing.T) {
 	evictioncMock := &evictionCallbackMock{}
 
 	tests := []struct {
 		name string
-		c    Cache[string, interface{}]
+		c    Imcache[string, interface{}]
 	}{
 		{
 			name: "not sharded",
@@ -1133,12 +1133,12 @@ func TestCache_RemoveStale_EvictionCallback(t *testing.T) {
 	}
 }
 
-func TestCache_GetAll_EvictionCallback(t *testing.T) {
+func TestImcache_GetAll_EvictionCallback(t *testing.T) {
 	evictioncMock := &evictionCallbackMock{}
 
 	tests := []struct {
 		name string
-		c    Cache[string, interface{}]
+		c    Imcache[string, interface{}]
 	}{
 		{
 			name: "not sharded",
@@ -1191,12 +1191,12 @@ func TestNewSharded_NilHasher(t *testing.T) {
 	_ = NewSharded[string, string](2, nil)
 }
 
-func TestCache_StartCleaner(t *testing.T) {
+func TestImcache_StartCleaner(t *testing.T) {
 	evictioncMock := &evictionCallbackMock{}
 
 	tests := []struct {
 		name string
-		c    Cache[string, interface{}]
+		c    Imcache[string, interface{}]
 	}{
 		{
 			name: "not sharded",
@@ -1253,12 +1253,12 @@ func TestCache_StartCleaner(t *testing.T) {
 	}
 }
 
-func TestCache_StopCleaner(t *testing.T) {
+func TestImcache_StopCleaner(t *testing.T) {
 	evictioncMock := &evictionCallbackMock{}
 
 	tests := []struct {
 		name string
-		c    Cache[string, interface{}]
+		c    Imcache[string, interface{}]
 	}{
 		{
 			name: "not sharded",

--- a/cache_test.go
+++ b/cache_test.go
@@ -1301,3 +1301,11 @@ func TestImcache_StopCleaner(t *testing.T) {
 		})
 	}
 }
+
+func TestCache_ZeroValue(t *testing.T) {
+	var c Cache[string, string]
+	c.Set("foo", "bar", WithNoExpiration())
+	if v, ok := c.Get("foo"); !ok || v != "bar" {
+		t.Errorf("want Cache.Get(_) = %s, true, got %s, %t", "bar", v, ok)
+	}
+}

--- a/option.go
+++ b/option.go
@@ -4,33 +4,33 @@ import "time"
 
 // Option is a Cache option.
 type Option[K comparable, V any] interface {
-	apply(*shard[K, V])
+	apply(*Cache[K, V])
 }
 
-type optionf[K comparable, V any] func(*shard[K, V])
+type optionf[K comparable, V any] func(*Cache[K, V])
 
 //lint:ignore U1000 false positive
-func (f optionf[K, V]) apply(c *shard[K, V]) {
+func (f optionf[K, V]) apply(c *Cache[K, V]) {
 	f(c)
 }
 
 // WithEvictionCallbackOption returns an Option that sets the Cache eviction callback.
 func WithEvictionCallbackOption[K comparable, V any](f EvictionCallback[K, V]) Option[K, V] {
-	return optionf[K, V](func(s *shard[K, V]) {
+	return optionf[K, V](func(s *Cache[K, V]) {
 		s.onEviction = f
 	})
 }
 
 // WithDefaultExpirationOption returns an Option that sets the Cache default expiration.
 func WithDefaultExpirationOption[K comparable, V any](d time.Duration) Option[K, V] {
-	return optionf[K, V](func(s *shard[K, V]) {
+	return optionf[K, V](func(s *Cache[K, V]) {
 		s.defaultExp = d
 	})
 }
 
 // WithDefaultSlidingExpirationOption returns an Option that sets the Cache default sliding expiration.
 func WithDefaultSlidingExpirationOption[K comparable, V any](d time.Duration) Option[K, V] {
-	return optionf[K, V](func(s *shard[K, V]) {
+	return optionf[K, V](func(s *Cache[K, V]) {
 		s.defaultExp = d
 		s.sliding = true
 	})


### PR DESCRIPTION
This PR exports concrete types for non-sharded cache (`Cache`) and sharded cache (`Sharded`).

Changes include:
* Rename `Cache` interface to `Imcache`
* Export a non-sharded cache type `Cache`
* Make `Cache` zero value ready to use
* Export a sharded cache type `Sharded`
* Update factory functions to return concrete types instead of interface