### PR TITLE
Prevent usage of LRU queue if not needed 

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -452,7 +452,6 @@ func (c *Cache[K, V]) Len() int {
 
 // StartCleaner starts a cleaner that periodically removes expired entries.
 // A cleaner runs in a separate goroutine.
-// It's a NOP method if the cleaner is already running.
 // It returns an error if the cleaner is already running
 // or if the interval is less than or equal to zero.
 //
@@ -643,7 +642,6 @@ func (s *Sharded[K, V]) Len() int {
 
 // StartCleaner starts a cleaner that periodically removes expired entries.
 // A cleaner runs in a separate goroutine.
-// It's a NOP method if the cleaner is already running.
 // It returns an error if the cleaner is already running
 // or if the interval is less than or equal to zero.
 //

--- a/option.go
+++ b/option.go
@@ -24,6 +24,9 @@ func WithEvictionCallbackOption[K comparable, V any](f EvictionCallback[K, V]) O
 // WithDefaultExpirationOption returns an Option that sets the Cache default expiration.
 func WithDefaultExpirationOption[K comparable, V any](d time.Duration) Option[K, V] {
 	return optionf[K, V](func(s *Cache[K, V]) {
+		if d <= 0 {
+			return
+		}
 		s.defaultExp = d
 	})
 }
@@ -31,6 +34,9 @@ func WithDefaultExpirationOption[K comparable, V any](d time.Duration) Option[K,
 // WithDefaultSlidingExpirationOption returns an Option that sets the Cache default sliding expiration.
 func WithDefaultSlidingExpirationOption[K comparable, V any](d time.Duration) Option[K, V] {
 	return optionf[K, V](func(s *Cache[K, V]) {
+		if d <= 0 {
+			return
+		}
 		s.defaultExp = d
 		s.sliding = true
 	})
@@ -43,6 +49,9 @@ func WithDefaultSlidingExpirationOption[K comparable, V any](d time.Duration) Op
 // not the total size of all shards.
 func WithMaxEntriesOption[K comparable, V any](n int) Option[K, V] {
 	return optionf[K, V](func(s *Cache[K, V]) {
+		if n <= 0 {
+			return
+		}
 		s.size = n
 		s.queue = &fifoq[K]{}
 	})

--- a/option.go
+++ b/option.go
@@ -16,29 +16,29 @@ func (f optionf[K, V]) apply(c *Cache[K, V]) {
 
 // WithEvictionCallbackOption returns an Option that sets the Cache eviction callback.
 func WithEvictionCallbackOption[K comparable, V any](f EvictionCallback[K, V]) Option[K, V] {
-	return optionf[K, V](func(s *Cache[K, V]) {
-		s.onEviction = f
+	return optionf[K, V](func(c *Cache[K, V]) {
+		c.onEviction = f
 	})
 }
 
 // WithDefaultExpirationOption returns an Option that sets the Cache default expiration.
 func WithDefaultExpirationOption[K comparable, V any](d time.Duration) Option[K, V] {
-	return optionf[K, V](func(s *Cache[K, V]) {
+	return optionf[K, V](func(c *Cache[K, V]) {
 		if d <= 0 {
 			return
 		}
-		s.defaultExp = d
+		c.defaultExp = d
 	})
 }
 
 // WithDefaultSlidingExpirationOption returns an Option that sets the Cache default sliding expiration.
 func WithDefaultSlidingExpirationOption[K comparable, V any](d time.Duration) Option[K, V] {
-	return optionf[K, V](func(s *Cache[K, V]) {
+	return optionf[K, V](func(c *Cache[K, V]) {
 		if d <= 0 {
 			return
 		}
-		s.defaultExp = d
-		s.sliding = true
+		c.defaultExp = d
+		c.sliding = true
 	})
 }
 
@@ -48,11 +48,11 @@ func WithDefaultSlidingExpirationOption[K comparable, V any](d time.Duration) Op
 // If used with Sharded type, the maximum size is per shard,
 // not the total size of all shards.
 func WithMaxEntriesOption[K comparable, V any](n int) Option[K, V] {
-	return optionf[K, V](func(s *Cache[K, V]) {
+	return optionf[K, V](func(c *Cache[K, V]) {
 		if n <= 0 {
 			return
 		}
-		s.size = n
-		s.queue = &fifoq[K]{}
+		c.size = n
+		c.queue = &fifoq[K]{}
 	})
 }


### PR DESCRIPTION
This PR prevents usage of additional data structure if not needed.

Fixes: https://github.com/erni27/imcache/issues/25