### PR TITLE
Rename `SizeExceeded` `EvictionReason` to `MaxEntriesExceeded`

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ c2.Set(1, "one", imcache.WithDefaultExpiration())
 
 ### Key eviction
 
-`imcache` follows very naive and simple eviction approach. If an expired entry is accessed by any `Cache` method, it is removed from the cache. The exception is the max entries limit. If the max entries limit is set, the cache  evicts the least recently used entry when the max entries limit is reached regardless of the expiration time. More on limiting the max number of entries in the cache can be found in the [Max entries limit](#max-entries-limit) section.
+`imcache` follows very naive and simple eviction approach. If an expired entry is accessed by any `Cache` method, it is removed from the cache. The exception is the max entries limit. If the max entries limit is set, the cache  evicts the least recently used entry when the max entries limit is reached regardless of its expiration time. More on limiting the max number of entries in the cache can be found in the [Max entries limit](#max-entries-limit) section.
 
 It is possible to use the `Cleaner` to periodically remove expired entries from the cache. The `Cleaner` is a background goroutine that periodically removes expired entries from the cache. The `Cleaner` is disabled by default. You can enable it by calling the `StartCleaner` method. The `Cleaner` can be stopped by calling the `StopCleaner` method.
 

--- a/README.md
+++ b/README.md
@@ -137,4 +137,4 @@ A `Sharded` instance can be created by calling the `NewSharded` method. It accep
 c := imcache.NewSharded[string, string](4, imcache.DefaultStringHasher64{})
 ```
 
-All previous examples apply to `Sharded` type as well. Note that `Option`(s) are applied to each shard not to the `Sharded` instance itself.
+All previous examples apply to `Sharded` type as well. Note that `Option`(s) are applied to each shard (`Cache` instance) not to the `Sharded` instance itself.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ func main() {
 
 ### Max entries limit
 
-`imcache` supports max entries limit. If the max entries limit is set, the cache evicts the least recently used entry when the max entries limit is reached. The least recently used entry is evicted regardless of the entry's expiration time.
+`imcache` supports max entries limit. If the max entries limit is set, the cache evicts the least recently used entry when the max entries limit is reached. The least recently used entry is evicted regardless of the entry's expiration time. This allows `imcache` to remain simple and efficient.
 
 LRU eviction is implemented using a doubly linked list. The list is ordered by the time of the last access to the entry. The most recently used entry is always at the head of the list. The least recently used entry is always at the tail of the list. It means that if the max entries limit is set, `Cache` maintains another data structure in addition to the map of entries. As a result, memory usage icreases.
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ func main() {
 
 ### Max entries limit
 
-`imcache` supports max entries limit. If the max entries limit is set, the cache evicts the least recently used entry when the max entries limit is reached regardless of the expiration time.
+`imcache` supports max entries limit. If the max entries limit is set, the cache evicts the least recently used entry when the max entries limit is reached. The least recently used entry is evicted regardless of the entry's expiration time.
 
 LRU eviction is implemented using a doubly linked list. The list is ordered by the time of the last access to the entry. The most recently used entry is always at the head of the list. The least recently used entry is always at the tail of the list. It means that if the max entries limit is set, `Cache` maintains another data structure in addition to the map of entries. It increases the memory usage and slightly decreases the write performance.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ import (
 
 func main() {
 	// Zero value Cache is a valid non-sharded cache
-	// with no expiration, no sliding expiration and no eviction callback.
+	// with no expiration, no sliding expiration,
+	// no entry limit and no eviction callback.
 	var c imcache.Cache[uint32, string]
 	// Set a new value with no expiration time.
 	c.Set(1, "one", imcache.WithNoExpiration())
@@ -53,16 +54,16 @@ c.Set(2, "two", imcache.WithSlidingExpiration(time.Second))
 c.Set(3, "three", imcache.WithExpiration(time.Second))
 ```
 
-If you want to use default expiration time for the given cache instance, you can use the `WithDefaultExpiration` `Expiration` option. By default the default expiration time is set to no expiration. You can set the default expiration time when creating a new `Cache` instance.
+If you want to use default expiration time for the given cache instance, you can use the `WithDefaultExpiration` `Expiration` option. By default the default expiration time is set to no expiration. You can set the default expiration time when creating a new `Cache` or a `Sharded` instance. More on sharding can be found in the [Sharding](#sharding) section.
 
 ```go
 // Create a new non-sharded cache instance with default absolute expiration time equal to 1 second.
-c1 := imcache.New(imcache.WithDefaultExpirationOption[int32, string](time.Second))
+c1 := imcache.New[int32, string](imcache.WithDefaultExpirationOption[int32, string](time.Second))
 // Set a new value with default expiration time (absolute).
 c1.Set(1, "one", imcache.WithDefaultExpiration())
 
 // Create a new non-sharded cache instance with default sliding expiration time equal to 1 second.
-c2 := imcache.New(imcache.WithDefaultSlidingExpirationOption[int32, string](time.Second))
+c2 := imcache.New[int32, string](imcache.WithDefaultSlidingExpirationOption[int32, string](time.Second))
 // Set a new value with default expiration time (sliding).
 c2.Set(1, "one", imcache.WithDefaultExpiration())
 ```
@@ -80,7 +81,7 @@ _ = c.StartCleaner(5 * time.Minute)
 defer c.StopCleaner()
 ```
 
-To be notified when an entry is evicted from the cache, you can use the `EvictionCallback`. It's a function that accepts the key and value of the evicted entry along with the reason why the entry was evicted. `EvictionCallback` can be configured when creating a new `Cache` or `Sharded` instance.
+To be notified when an entry is evicted from the cache, you can use the `EvictionCallback`. It's a function that accepts the key and value of the evicted entry along with the reason why the entry was evicted. `EvictionCallback` can be configured when creating a new `Cache` or a `Sharded` instance.
 
 ```go
 package main
@@ -97,9 +98,9 @@ func LogEvictedEntry(key string, value interface{}, reason imcache.EvictionReaso
 }
 
 func main() {
-	c := imcache.New(
+	c := imcache.New[string, interface{}](
 		imcache.WithDefaultExpirationOption[string, interface{}](time.Second),
-		imcache.WithEvictionCallbackOption(LogEvictedEntry),
+		imcache.WithEvictionCallbackOption[string, interface{}](LogEvictedEntry),
 	)
 	c.Set("foo", "bar", imcache.WithDefaultExpiration())
 
@@ -121,7 +122,7 @@ LRU eviction is implemented using a doubly linked list. The list is ordered by t
 The max entries limit can be configured when creating a new `Cache` instance.
 
 ```go
-c := imcache.New(imcache.WithMaxEntriesOption[uint32, string](1000))
+c := imcache.New[uint32, string](imcache.WithMaxEntriesOption[uint32, string](1000))
 ```
 
 ### Sharding

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ func main() {
 
 `imcache` supports max entries limit. If the max entries limit is set, the cache evicts the least recently used entry when the max entries limit is reached. The least recently used entry is evicted regardless of the entry's expiration time.
 
-LRU eviction is implemented using a doubly linked list. The list is ordered by the time of the last access to the entry. The most recently used entry is always at the head of the list. The least recently used entry is always at the tail of the list. It means that if the max entries limit is set, `Cache` maintains another data structure in addition to the map of entries. It increases the memory usage and slightly decreases the write performance.
+LRU eviction is implemented using a doubly linked list. The list is ordered by the time of the last access to the entry. The most recently used entry is always at the head of the list. The least recently used entry is always at the tail of the list. It means that if the max entries limit is set, `Cache` maintains another data structure in addition to the map of entries. As a result, memory usage icreases.
 
 The max entries limit can be configured when creating a new `Cache` instance.
 

--- a/cache.go
+++ b/cache.go
@@ -482,8 +482,8 @@ func (c *Cache[K, V]) StopCleaner() {
 // no eviction callback.
 //
 // Option(s) can be used to customize the returned Sharded.
-// Note that Option(s) are applied to each shard not to
-// Sharded instance itself.
+// Note that Option(s) are applied to each shard (Cache instance)
+// not to the Sharded instance itself.
 func NewSharded[K comparable, V any](n int, hasher Hasher64[K], opts ...Option[K, V]) *Sharded[K, V] {
 	if n <= 0 {
 		panic("imcache: number of shards must be greater than 0")

--- a/cache.go
+++ b/cache.go
@@ -15,9 +15,9 @@ import (
 
 // New returns a new Cache instance.
 //
-// By default a returned Cache has no default expiration,
-// no default sliding expiration, no entry limit
-// and no eviction callback.
+// By default a returned Cache has no default expiration, no default sliding
+// expiration, no entry limit and no eviction callback.
+//
 // Option(s) can be used to customize the returned Cache.
 func New[K comparable, V any](opts ...Option[K, V]) *Cache[K, V] {
 	s := &Cache[K, V]{
@@ -108,8 +108,9 @@ func (c *Cache[K, V]) Get(key K) (V, bool) {
 //
 // If it encounters an expired entry, it is evicted and a new entry is added.
 //
-// If you don't want to replace an existing entry, use the GetOrSet method instead.
-// If you don't want to add a new entry if it doesn't exist, use the Replace method instead.
+// If you don't want to replace an existing entry, use the GetOrSet method
+// instead. If you don't want to add a new entry if it doesn't exist, use
+// the Replace method instead.
 func (c *Cache[K, V]) Set(key K, val V, exp Expiration) {
 	now := time.Now()
 	entry := entry[K, V]{val: val}
@@ -149,12 +150,13 @@ func (c *Cache[K, V]) Set(key K, val V, exp Expiration) {
 	if toevict.HasExpired(now) {
 		c.onEviction(node.key, toevict.val, EvictionReasonExpired)
 	} else {
-		c.onEviction(node.key, toevict.val, EvictionReasonSizeExceeded)
+		c.onEviction(node.key, toevict.val, EvictionReasonMaxEntriesExceeded)
 	}
 }
 
 // GetOrSet returns the value for the given key and true if it exists,
-// otherwise it sets the value for the given key and returns the set value and false.
+// otherwise it sets the value for the given key and returns the set value
+// and false.
 //
 // If it encounters an expired entry, the expired entry is evicted.
 func (c *Cache[K, V]) GetOrSet(key K, val V, exp Expiration) (V, bool) {
@@ -185,7 +187,7 @@ func (c *Cache[K, V]) GetOrSet(key K, val V, exp Expiration) (V, bool) {
 		if toevict.HasExpired(now) {
 			c.onEviction(node.key, toevict.val, EvictionReasonExpired)
 		} else {
-			c.onEviction(node.key, toevict.val, EvictionReasonSizeExceeded)
+			c.onEviction(node.key, toevict.val, EvictionReasonMaxEntriesExceeded)
 		}
 		return val, false
 	}
@@ -209,7 +211,8 @@ func (c *Cache[K, V]) GetOrSet(key K, val V, exp Expiration) (V, bool) {
 }
 
 // Replace replaces the value for the given key.
-// It returns true if the value is present and replaced, otherwise it returns false.
+// It returns true if the value is present and replaced, otherwise it returns
+// false.
 //
 // If it encounters an expired entry, the expired entry is evicted.
 //
@@ -244,14 +247,15 @@ func (c *Cache[K, V]) Replace(key K, val V, exp Expiration) bool {
 	return true
 }
 
-// ReplaceWithFunc replaces the value for the given key
-// with the result of the given function that takes the old value as an argument.
-// It returns true if the value is present and replaced, otherwise it returns false.
+// ReplaceWithFunc replaces the value for the given key with the result
+// of the given function that takes the old value as an argument.
+// It returns true if the value is present and replaced, otherwise it returns
+// false.
 //
 // If it encounters an expired entry, the expired entry is evicted.
 //
-// If you want to replace the value with a new value not depending on the old value,
-// use the Replace method instead.
+// If you want to replace the value with a new value not depending on the old
+// value, use the Replace method instead.
 //
 // imcache provides the Increment and Decrement functions that can be used as f
 // to increment or decrement the old numeric type value.
@@ -543,14 +547,16 @@ func (s *Sharded[K, V]) Get(key K) (V, bool) {
 //
 // If it encounters an expired entry, it is evicted and a new entry is added.
 //
-// If you don't want to replace an existing entry, use the GetOrSet method instead.
-// If you don't want to add a new entry if it doesn't exist, use the Replace method instead.
+// If you don't want to replace an existing entry, use the GetOrSet method
+// instead. If you don't want to add a new entry if it doesn't exist, use
+// the Replace method instead.
 func (s *Sharded[K, V]) Set(key K, val V, exp Expiration) {
 	s.shard(key).Set(key, val, exp)
 }
 
 // GetOrSet returns the value for the given key and true if it exists,
-// otherwise it sets the value for the given key and returns the set value and false.
+// otherwise it sets the value for the given key and returns the set value
+// and false.
 //
 // If it encounters an expired entry, the expired entry is evicted.
 func (s *Sharded[K, V]) GetOrSet(key K, val V, exp Expiration) (v V, present bool) {
@@ -558,7 +564,8 @@ func (s *Sharded[K, V]) GetOrSet(key K, val V, exp Expiration) (v V, present boo
 }
 
 // Replace replaces the value for the given key.
-// It returns true if the value is present and replaced, otherwise it returns false.
+// It returns true if the value is present and replaced, otherwise it returns
+// false.
 //
 // If it encounters an expired entry, the expired entry is evicted.
 //
@@ -567,14 +574,15 @@ func (s *Sharded[K, V]) Replace(key K, val V, exp Expiration) bool {
 	return s.shard(key).Replace(key, val, exp)
 }
 
-// ReplaceWithFunc replaces the value for the given key
-// with the result of the given function that takes the old value as an argument.
-// It returns true if the value is present and replaced, otherwise it returns false.
+// ReplaceWithFunc replaces the value for the given key with the result
+// of the given function that takes the old value as an argument.
+// It returns true if the value is present and replaced, otherwise it returns
+// false.
 //
 // If it encounters an expired entry, the expired entry is evicted.
 //
-// If you want to replace the value with a new value not depending on the old value,
-// use the Replace method instead.
+// If you want to replace the value with a new value not depending on the old
+// value, use the Replace method instead.
 //
 // imcache provides the Increment and Decrement functions that can be used as f
 // to increment or decrement the old numeric type value.

--- a/cache_test.go
+++ b/cache_test.go
@@ -1398,8 +1398,8 @@ func TestCache_MaxEntries(t *testing.T) {
 	if _, ok := c.Get("one"); ok {
 		t.Error("want Cache.Get(_) = _, false, got _, true")
 	}
-	if !evictioncMock.HasBeenCalledWith("one", 1, EvictionReasonSizeExceeded) {
-		t.Errorf("want EvictionCallback called with EvictionCallback(%s, %d, %d)", "one", 1, EvictionReasonSizeExceeded)
+	if !evictioncMock.HasBeenCalledWith("one", 1, EvictionReasonMaxEntriesExceeded) {
+		t.Errorf("want EvictionCallback called with EvictionCallback(%s, %d, %d)", "one", 1, EvictionReasonMaxEntriesExceeded)
 	}
 
 	// Get should move the entry to the front of the queue.
@@ -1412,8 +1412,8 @@ func TestCache_MaxEntries(t *testing.T) {
 	if _, ok := c.Get("three"); ok {
 		t.Error("want Cache.Get(_) = _, false, got _, true")
 	}
-	if !evictioncMock.HasBeenCalledWith("three", 3, EvictionReasonSizeExceeded) {
-		t.Errorf("want EvictionCallback called with EvictionCallback(%s, %d, %d)", "three", 3, EvictionReasonSizeExceeded)
+	if !evictioncMock.HasBeenCalledWith("three", 3, EvictionReasonMaxEntriesExceeded) {
+		t.Errorf("want EvictionCallback called with EvictionCallback(%s, %d, %d)", "three", 3, EvictionReasonMaxEntriesExceeded)
 	}
 
 	// Set should evict the last entry from the queue if the size is exceeded
@@ -1437,8 +1437,8 @@ func TestCache_MaxEntries(t *testing.T) {
 	if _, ok := c.Get("six"); ok {
 		t.Error("want Cache.Get(_) = _, false, got _, true")
 	}
-	if !evictioncMock.HasBeenCalledWith("six", 6, EvictionReasonSizeExceeded) {
-		t.Errorf("want EvictionCallback called with EvictionCallback(%s, %d, %d)", "six", 6, EvictionReasonSizeExceeded)
+	if !evictioncMock.HasBeenCalledWith("six", 6, EvictionReasonMaxEntriesExceeded) {
+		t.Errorf("want EvictionCallback called with EvictionCallback(%s, %d, %d)", "six", 6, EvictionReasonMaxEntriesExceeded)
 	}
 
 	// ReplaceWithFunc should update the entry and move it to the front of the queue.
@@ -1451,8 +1451,8 @@ func TestCache_MaxEntries(t *testing.T) {
 	if _, ok := c.Get("seven"); ok {
 		t.Error("want Cache.Get(_) = _, false, got _, true")
 	}
-	if !evictioncMock.HasBeenCalledWith("seven", 7, EvictionReasonSizeExceeded) {
-		t.Errorf("want EvictionCallback called with EvictionCallback(%s, %d, %d)", "seven", 7, EvictionReasonSizeExceeded)
+	if !evictioncMock.HasBeenCalledWith("seven", 7, EvictionReasonMaxEntriesExceeded) {
+		t.Errorf("want EvictionCallback called with EvictionCallback(%s, %d, %d)", "seven", 7, EvictionReasonMaxEntriesExceeded)
 	}
 
 	// Set should not evict any entry if the size is not exceeded.
@@ -1471,8 +1471,8 @@ func TestCache_MaxEntries(t *testing.T) {
 	if _, ok := c.Get("five"); ok {
 		t.Error("want Cache.Get(_) = _, false, got _, true")
 	}
-	if !evictioncMock.HasBeenCalledWith("five", 5, EvictionReasonSizeExceeded) {
-		t.Errorf("want EvictionCallback called with EvictionCallback(%s, %d, %d)", "five", 5, EvictionReasonSizeExceeded)
+	if !evictioncMock.HasBeenCalledWith("five", 5, EvictionReasonMaxEntriesExceeded) {
+		t.Errorf("want EvictionCallback called with EvictionCallback(%s, %d, %d)", "five", 5, EvictionReasonMaxEntriesExceeded)
 	}
 
 	// Remove should not mess with the LRU queue.
@@ -1491,8 +1491,8 @@ func TestCache_MaxEntries(t *testing.T) {
 	if _, ok := c.Get("ten"); ok {
 		t.Error("want Cache.Get(_) = _, false, got _, true")
 	}
-	if !evictioncMock.HasBeenCalledWith("ten", 10, EvictionReasonSizeExceeded) {
-		t.Errorf("want EvictionCallback called with EvictionCallback(%s, %d, %d)", "ten", 10, EvictionReasonSizeExceeded)
+	if !evictioncMock.HasBeenCalledWith("ten", 10, EvictionReasonMaxEntriesExceeded) {
+		t.Errorf("want EvictionCallback called with EvictionCallback(%s, %d, %d)", "ten", 10, EvictionReasonMaxEntriesExceeded)
 	}
 
 	// RemoveAll reset the LRU queue.
@@ -1513,8 +1513,8 @@ func TestCache_MaxEntries(t *testing.T) {
 	if _, ok := c.Get("fifteen"); ok {
 		t.Error("Cache.Get(_) = _, true, got _, false")
 	}
-	if !evictioncMock.HasBeenCalledWith("fifteen", 15, EvictionReasonSizeExceeded) {
-		t.Errorf("want EvictionCallback called with EvictionCallback(%s, %d, %d)", "fifteen", 15, EvictionReasonSizeExceeded)
+	if !evictioncMock.HasBeenCalledWith("fifteen", 15, EvictionReasonMaxEntriesExceeded) {
+		t.Errorf("want EvictionCallback called with EvictionCallback(%s, %d, %d)", "fifteen", 15, EvictionReasonMaxEntriesExceeded)
 	}
 
 	// RemoveStale should not mess with the LRU queue.
@@ -1541,8 +1541,8 @@ func TestCache_MaxEntries(t *testing.T) {
 	if _, ok := c.Get("fourteen"); ok {
 		t.Error("Cache.Get(_) = _, true, got _, false")
 	}
-	if !evictioncMock.HasBeenCalledWith("fourteen", 14, EvictionReasonSizeExceeded) {
-		t.Errorf("want EvictionCallback called with EvictionCallback(%s, %d, %d)", "fourteen", 14, EvictionReasonSizeExceeded)
+	if !evictioncMock.HasBeenCalledWith("fourteen", 14, EvictionReasonMaxEntriesExceeded) {
+		t.Errorf("want EvictionCallback called with EvictionCallback(%s, %d, %d)", "fourteen", 14, EvictionReasonMaxEntriesExceeded)
 	}
 
 	// GetOrSet should move the entry to the front of the LRU queue.

--- a/eviction.go
+++ b/eviction.go
@@ -16,8 +16,9 @@ const (
 	// EvictionReasonMaxEntriesExceeded indicates that the entry was evicted
 	// because the max entries limit was exceeded.
 	//
-	// imcache uses LRU eviction policy when the cache exceeds
-	// the max entries limit regardless of the entry expiration time.
+	// imcache uses LRU eviction policy when the cache exceeds the max entries
+	// limit. The least recently used entry is evicted regardless of the
+	// entry's expiration time.
 	EvictionReasonMaxEntriesExceeded
 )
 

--- a/eviction.go
+++ b/eviction.go
@@ -31,7 +31,7 @@ func (r EvictionReason) String() string {
 	case EvictionReasonReplaced:
 		return "replaced"
 	case EvictionReasonMaxEntriesExceeded:
-		return "size exceeded"
+		return "max entries limit exceeded"
 	default:
 		return "unknown"
 	}

--- a/eviction.go
+++ b/eviction.go
@@ -4,15 +4,21 @@ package imcache
 type EvictionReason int32
 
 const (
-	// EvictionReasonExpired indicates that the entry was evicted because it expired.
+	// EvictionReasonExpired indicates that the entry was evicted
+	// because it expired.
 	EvictionReasonExpired EvictionReason = iota + 1
-	// EvictionReasonRemoved indicates that the entry was evicted because it was removed.
+	// EvictionReasonRemoved indicates that the entry was evicted
+	// because it was removed.
 	EvictionReasonRemoved
-	// EvictionReasonReplaced indicates that the entry was evicted because it was replaced.
+	// EvictionReasonReplaced indicates that the entry was evicted
+	// because it was replaced.
 	EvictionReasonReplaced
-	// EvictionReasonSizeExceeded indicates that the entry was evicted because the cache size exceeded.
-	// imcache uses LRU eviction policy when the cache size exceeds the maximum size.
-	EvictionReasonSizeExceeded
+	// EvictionReasonMaxEntriesExceeded indicates that the entry was evicted
+	// because the max entries limit was exceeded.
+	//
+	// imcache uses LRU eviction policy when the cache exceeds
+	// the max entries limit regardless of the entry expiration time.
+	EvictionReasonMaxEntriesExceeded
 )
 
 func (r EvictionReason) String() string {
@@ -23,12 +29,13 @@ func (r EvictionReason) String() string {
 		return "removed"
 	case EvictionReasonReplaced:
 		return "replaced"
-	case EvictionReasonSizeExceeded:
+	case EvictionReasonMaxEntriesExceeded:
 		return "size exceeded"
 	default:
 		return "unknown"
 	}
 }
 
-// EvictionCallback is the callback function that is called when an entry is evicted.
+// EvictionCallback is the callback function that is called when an entry
+// is evicted.
 type EvictionCallback[K comparable, V any] func(key K, val V, reason EvictionReason)

--- a/expiration.go
+++ b/expiration.go
@@ -23,7 +23,8 @@ func (f expirationf) apply(e *expiration) {
 	f(e)
 }
 
-// WithExpiration returns an Expiration that sets the expiration time to now + d.
+// WithExpiration returns an Expiration that sets the expiration time
+// to now + d.
 func WithExpiration(d time.Duration) Expiration {
 	return expirationf(func(e *expiration) {
 		e.date = time.Now().Add(d).UnixNano()
@@ -46,15 +47,16 @@ func WithSlidingExpiration(d time.Duration) Expiration {
 	})
 }
 
-// WithNoExpiration returns an Expiration that sets the expiration time to never expire.
+// WithNoExpiration returns an Expiration that sets the expiration time
+// to never expire.
 func WithNoExpiration() Expiration {
 	return expirationf(func(e *expiration) {
 		e.date = noExp
 	})
 }
 
-// WithDefaultExpiration returns an Expiration that sets the expiration time to the
-// default expiration time.
+// WithDefaultExpiration returns an Expiration that sets the expiration time
+// to the default expiration time.
 func WithDefaultExpiration() Expiration {
 	return expirationf(func(e *expiration) {
 		e.date = defaultExp

--- a/option.go
+++ b/option.go
@@ -47,7 +47,7 @@ func WithDefaultSlidingExpirationOption[K comparable, V any](d time.Duration) Op
 
 // WithMaxEntriesOption returns an Option that sets the Cache maximum number
 // of entries. When the maximum number of entries is exceeded, the least
-// recently used entry is evicted regardless of the entry expiration time.
+// recently used entry is evicted regardless of the entry's expiration time.
 //
 // If used with Sharded type, the maximum size is per shard,
 // not the total size of all shards.

--- a/option.go
+++ b/option.go
@@ -14,14 +14,16 @@ func (f optionf[K, V]) apply(c *Cache[K, V]) {
 	f(c)
 }
 
-// WithEvictionCallbackOption returns an Option that sets the Cache eviction callback.
+// WithEvictionCallbackOption returns an Option that sets the Cache
+// eviction callback.
 func WithEvictionCallbackOption[K comparable, V any](f EvictionCallback[K, V]) Option[K, V] {
 	return optionf[K, V](func(c *Cache[K, V]) {
 		c.onEviction = f
 	})
 }
 
-// WithDefaultExpirationOption returns an Option that sets the Cache default expiration.
+// WithDefaultExpirationOption returns an Option that sets the Cache
+// default expiration.
 func WithDefaultExpirationOption[K comparable, V any](d time.Duration) Option[K, V] {
 	return optionf[K, V](func(c *Cache[K, V]) {
 		if d <= 0 {
@@ -31,7 +33,8 @@ func WithDefaultExpirationOption[K comparable, V any](d time.Duration) Option[K,
 	})
 }
 
-// WithDefaultSlidingExpirationOption returns an Option that sets the Cache default sliding expiration.
+// WithDefaultSlidingExpirationOption returns an Option that sets the Cache
+// default sliding expiration.
 func WithDefaultSlidingExpirationOption[K comparable, V any](d time.Duration) Option[K, V] {
 	return optionf[K, V](func(c *Cache[K, V]) {
 		if d <= 0 {
@@ -42,8 +45,9 @@ func WithDefaultSlidingExpirationOption[K comparable, V any](d time.Duration) Op
 	})
 }
 
-// WithMaxEntriesOption returns an Option that sets the Cache maximum number of entries.
-// When the maximum number of entries is exceeded, the least recently used entry is evicted.
+// WithMaxEntriesOption returns an Option that sets the Cache maximum number
+// of entries. When the maximum number of entries is exceeded, the least
+// recently used entry is evicted regardless of the entry expiration time.
 //
 // If used with Sharded type, the maximum size is per shard,
 // not the total size of all shards.


### PR DESCRIPTION
This PR renames `EvictionReasonSizeExceeded` to `EvictionReasonMaxEntriesExceeded`.

It makes the API more consistent.