### PR TITLE
Rename `RemoveStale` to `RemoveExpired`

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -357,7 +357,7 @@ func (c *Cache[K, V]) RemoveAll() {
 	c.removeAll(time.Now())
 }
 
-func (c *Cache[K, V]) removeStale(now time.Time) {
+func (c *Cache[K, V]) removeExpired(now time.Time) {
 	c.mu.Lock()
 	// To avoid copying the expired entries if there's no eviction callback.
 	if c.onEviction == nil {
@@ -383,11 +383,11 @@ func (c *Cache[K, V]) removeStale(now time.Time) {
 	}
 }
 
-// RemoveStale removes all expired entries.
+// RemoveExpired removes all expired entries.
 //
 // If an eviction callback is set, it is called for each removed entry.
-func (c *Cache[K, V]) RemoveStale() {
-	c.removeStale(time.Now())
+func (c *Cache[K, V]) RemoveExpired() {
+	c.removeExpired(time.Now())
 }
 
 type kv[K comparable, V any] struct {
@@ -622,13 +622,13 @@ func (s *Sharded[K, V]) RemoveAll() {
 	}
 }
 
-// RemoveStale removes all expired entries.
+// RemoveExpired removes all expired entries.
 //
 // If an eviction callback is set, it is called for each removed entry.
-func (s *Sharded[K, V]) RemoveStale() {
+func (s *Sharded[K, V]) RemoveExpired() {
 	now := time.Now()
 	for _, shard := range s.shards {
-		shard.removeStale(now)
+		shard.removeExpired(now)
 	}
 }
 

--- a/cleaner.go
+++ b/cleaner.go
@@ -6,9 +6,9 @@ import (
 	"time"
 )
 
-// remover is an interface that wraps the RemoveStale method.
-type remover interface {
-	RemoveStale()
+// eremover is an interface that wraps the RemoveExpired method.
+type eremover interface {
+	RemoveExpired()
 }
 
 func newCleaner() *cleaner {
@@ -25,7 +25,7 @@ type cleaner struct {
 	doneCh  chan struct{}
 }
 
-func (c *cleaner) start(r remover, interval time.Duration) error {
+func (c *cleaner) start(r eremover, interval time.Duration) error {
 	if interval <= 0 {
 		return errors.New("imcache: interval must be greater than 0")
 	}
@@ -44,7 +44,7 @@ func (c *cleaner) start(r remover, interval time.Duration) error {
 		for {
 			select {
 			case <-ticker.C:
-				r.RemoveStale()
+				r.RemoveExpired()
 			case <-c.stopCh:
 				close(c.doneCh)
 				return


### PR DESCRIPTION
This PR renames `RemoveStale` to `RemoveExpired`.

It makes the API more consistent.