### PR TITLE
Add `Close` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ c2.Set(1, "one", imcache.WithDefaultExpiration())
 It is possible to use the `Cleaner` to periodically remove expired entries from the cache. The `Cleaner` is a background goroutine that periodically removes expired entries from the cache. The `Cleaner` is disabled by default. You can enable it when creating a new `Cache` or `Sharded` instance. `Cleaner` is stopped when the cache is closed.
 
 ```go
-// Create a new Cache with the Cleaner which will remove expired entries every 5 minutes.
+// Create a new Cache with a Cleaner which will remove expired entries every 5 minutes.
 c := imcache.New[string, string](imcache.WithCleanerOption[string, string](5 * time.Minute))
-// Close closes the Cache and stops the Cleaner.
+// Close the Cache. This will stop the Cleaner if it is running.
 defer c.Close()
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![GoDoc](https://pkg.go.dev/badge/mod/github.com/erni27/imcache)](https://pkg.go.dev/mod/github.com/erni27/imcache)
 [![Coverage Status](https://codecov.io/gh/erni27/imcache/branch/master/graph/badge.svg)](https://codecov.io/gh/erni27/imcache)
 
-`imcache` is a generic in-memory cache Go library.
+`imcache` is a zero-dependency generic in-memory cache Go library.
 
 It supports absolute expiration, sliding expiration, max entries limit, eviction callbacks and sharding. It's safe for concurrent use by multiple goroutines.
 
@@ -83,13 +83,13 @@ c2.Set(1, "one", imcache.WithDefaultExpiration())
 
 `imcache` follows very naive and simple eviction approach. If an expired entry is accessed by any `Cache` method, it is removed from the cache. The exception is the max entries limit. If the max entries limit is set, the cache  evicts the least recently used entry when the max entries limit is reached regardless of its expiration time. More on limiting the max number of entries in the cache can be found in the [Max entries limit](#max-entries-limit) section.
 
-It is possible to use the `Cleaner` to periodically remove expired entries from the cache. The `Cleaner` is a background goroutine that periodically removes expired entries from the cache. The `Cleaner` is disabled by default. You can enable it by calling the `StartCleaner` method. The `Cleaner` can be stopped by calling the `StopCleaner` method.
+It is possible to use the `Cleaner` to periodically remove expired entries from the cache. The `Cleaner` is a background goroutine that periodically removes expired entries from the cache. The `Cleaner` is disabled by default. You can enable it when creating a new `Cache` or `Sharded` instance. `Cleaner` is stopped when the cache is closed.
 
 ```go
-var c imcache.Cache[string, string]
-// Start Cleaner which will remove expired entries every 5 minutes.
-_ = c.StartCleaner(5 * time.Minute)
-defer c.StopCleaner()
+// Create a new Cache with the Cleaner which will remove expired entries every 5 minutes.
+c := imcache.New[string, string](imcache.WithCleanerOption[string, string](5 * time.Minute))
+// Close closes the Cache and stops the Cleaner.
+defer c.Close()
 ```
 
 To be notified when an entry is evicted from the cache, you can use the `EvictionCallback`. It's a function that accepts the key and value of the evicted entry along with the reason why the entry was evicted. `EvictionCallback` can be configured when creating a new `Cache` or `Sharded` instance.

--- a/eviction.go
+++ b/eviction.go
@@ -113,4 +113,7 @@ func (*nopq[K]) Add(*node[K]) {}
 
 func (*nopq[K]) Remove(*node[K]) {}
 
-func (*nopq[K]) Pop() *node[K] { return nil }
+func (*nopq[K]) Pop() *node[K] {
+	// imcache is carefully designed to never call Pop on a NOP queue.
+	panic("imcache: Pop called on a NOP queue")
+}

--- a/imcache.go
+++ b/imcache.go
@@ -559,7 +559,7 @@ func NewSharded[K comparable, V any](n int, hasher Hasher64[K], opts ...Option[K
 		opt.apply(&o)
 	}
 	cleanerInterval := o.cleanerInterval
-	// To prevent a cleaner from starting for each shard.
+	// To prevent running the cleaner in each shard.
 	o.cleanerInterval = 0
 	shards := make([]*Cache[K, V], n)
 	for i := 0; i < n; i++ {

--- a/imcache.go
+++ b/imcache.go
@@ -520,6 +520,11 @@ func (c *Cache[K, V]) len() int {
 // Close closes the cache. It purges all entries and stops the cleaner
 // if it is running. After Close, all other methods are NOP returning
 // zero values immediately.
+//
+// It is safe to call Close multiple times.
+//
+// It's not necessary to call Close if the cache is no longer referenced
+// and there is no cleaner running. Garbage collector will collect the cache.
 func (c *Cache[K, V]) Close() {
 	c.mu.Lock()
 	if c.closed {
@@ -747,6 +752,11 @@ func (s *Sharded[K, V]) Len() int {
 // Close closes the cache. It purges all entries and stops the cleaner
 // if it is running. After Close, all other methods are NOP returning
 // zero values immediately.
+//
+// It is safe to call Close multiple times.
+//
+// It's not necessary to call Close if the cache is no longer referenced
+// and there is no cleaner running. Garbage collector will collect the cache.
 func (s *Sharded[K, V]) Close() {
 	for _, shard := range s.shards {
 		shard.Close()

--- a/imcache.go
+++ b/imcache.go
@@ -20,14 +20,32 @@ import (
 //
 // Option(s) can be used to customize the returned Cache.
 func New[K comparable, V any](opts ...Option[K, V]) *Cache[K, V] {
+	o := options[K, V]{defaultExp: noExp}
+	for _, opt := range opts {
+		opt.apply(&o)
+	}
+	return newCache(o)
+}
+
+func newCache[K comparable, V any](opts options[K, V]) *Cache[K, V] {
 	c := &Cache[K, V]{
 		m:          make(map[K]entry[K, V]),
-		defaultExp: -1,
-		cleaner:    newCleaner(),
-		queue:      &nopq[K]{},
+		onEviction: opts.onEviction,
+		defaultExp: opts.defaultExp,
+		sliding:    opts.sliding,
 	}
-	for _, opt := range opts {
-		opt.apply(c)
+	if opts.maxEntriesLimit > 0 {
+		c.queue = &lruq[K]{}
+		c.maxEntriesLimit = opts.maxEntriesLimit
+	} else {
+		c.queue = &nopq[K]{}
+	}
+	if opts.cleanerInterval > 0 {
+		c.cleaner = newCleaner()
+		if err := c.cleaner.start(c, opts.cleanerInterval); err != nil {
+			// With current sanitization this should never happen.
+			panic(err)
+		}
 	}
 	return c
 }
@@ -53,15 +71,17 @@ type Cache[K comparable, V any] struct {
 	mu sync.Mutex
 	m  map[K]entry[K, V]
 
-	queue evictionq[K]
-	size  int
-
 	defaultExp time.Duration
 	sliding    bool
 
 	onEviction EvictionCallback[K, V]
 
+	queue           evictionq[K]
+	maxEntriesLimit int
+
 	cleaner *cleaner
+
+	closed bool
 }
 
 // init initializes the Cache.
@@ -78,12 +98,16 @@ func (s *Cache[K, V]) init() {
 // If it encounters an expired entry, the expired entry is evicted.
 func (c *Cache[K, V]) Get(key K) (V, bool) {
 	now := time.Now()
-	var empty V
+	var zero V
 	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return zero, false
+	}
 	current, ok := c.m[key]
 	if !ok {
 		c.mu.Unlock()
-		return empty, false
+		return zero, false
 	}
 	c.queue.Remove(current.node)
 	if current.HasExpired(now) {
@@ -92,7 +116,7 @@ func (c *Cache[K, V]) Get(key K) (V, bool) {
 		if c.onEviction != nil {
 			c.onEviction(key, current.val, EvictionReasonExpired)
 		}
-		return empty, false
+		return zero, false
 	}
 	if current.HasSlidingExpiration() {
 		current.SlideExpiration(now)
@@ -117,6 +141,10 @@ func (c *Cache[K, V]) Set(key K, val V, exp Expiration) {
 	exp.apply(&new.exp)
 	new.SetDefaultOrNothing(now, c.defaultExp, c.sliding)
 	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
 	// Make sure that the shard is initialized.
 	c.init()
 	new.node = c.queue.AddNew(key)
@@ -134,7 +162,7 @@ func (c *Cache[K, V]) Set(key K, val V, exp Expiration) {
 		}
 		return
 	}
-	if c.size <= 0 || c.len() <= c.size {
+	if c.maxEntriesLimit <= 0 || c.len() <= c.maxEntriesLimit {
 		c.mu.Unlock()
 		return
 	}
@@ -165,13 +193,18 @@ func (c *Cache[K, V]) GetOrSet(key K, val V, exp Expiration) (V, bool) {
 	exp.apply(&new.exp)
 	new.SetDefaultOrNothing(now, c.defaultExp, c.sliding)
 	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		var zero V
+		return zero, false
+	}
 	// Make sure that the shard is initialized.
 	c.init()
 	current, ok := c.m[key]
 	if !ok {
 		new.node = c.queue.AddNew(key)
 		c.m[key] = new
-		if c.size <= 0 || c.len() <= c.size {
+		if c.maxEntriesLimit <= 0 || c.len() <= c.maxEntriesLimit {
 			c.mu.Unlock()
 			return val, false
 		}
@@ -223,6 +256,10 @@ func (c *Cache[K, V]) Replace(key K, val V, exp Expiration) bool {
 	exp.apply(&new.exp)
 	new.SetDefaultOrNothing(now, c.defaultExp, c.sliding)
 	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return false
+	}
 	current, ok := c.m[key]
 	if !ok {
 		c.mu.Unlock()
@@ -268,6 +305,10 @@ func (c *Cache[K, V]) Replace(key K, val V, exp Expiration) bool {
 func (c *Cache[K, V]) ReplaceWithFunc(key K, f func(V) V, exp Expiration) bool {
 	now := time.Now()
 	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return false
+	}
 	current, ok := c.m[key]
 	if !ok {
 		c.mu.Unlock()
@@ -305,6 +346,10 @@ func (c *Cache[K, V]) ReplaceWithFunc(key K, f func(V) V, exp Expiration) bool {
 func (c *Cache[K, V]) Remove(key K) bool {
 	now := time.Now()
 	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return false
+	}
 	current, ok := c.m[key]
 	if !ok {
 		c.mu.Unlock()
@@ -324,11 +369,26 @@ func (c *Cache[K, V]) Remove(key K) bool {
 	return true
 }
 
+// RemoveAll removes all entries.
+//
+// If an eviction callback is set, it is called for each removed entry.
+//
+// If it encounters an expired entry, the expired entry is evicted.
+// It results in calling the eviction callback with EvictionReasonExpired,
+// not EvictionReasonRemoved.
+func (c *Cache[K, V]) RemoveAll() {
+	c.removeAll(time.Now())
+}
+
 func (c *Cache[K, V]) removeAll(now time.Time) {
 	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
 	removed := c.m
 	c.m = make(map[K]entry[K, V])
-	if c.size > 0 {
+	if c.maxEntriesLimit > 0 {
 		c.queue = &lruq[K]{}
 	} else {
 		c.queue = &nopq[K]{}
@@ -345,19 +405,19 @@ func (c *Cache[K, V]) removeAll(now time.Time) {
 	}
 }
 
-// RemoveAll removes all entries.
+// RemoveExpired removes all expired entries.
 //
 // If an eviction callback is set, it is called for each removed entry.
-//
-// If it encounters an expired entry, the expired entry is evicted.
-// It results in calling the eviction callback with EvictionReasonExpired,
-// not EvictionReasonRemoved.
-func (c *Cache[K, V]) RemoveAll() {
-	c.removeAll(time.Now())
+func (c *Cache[K, V]) RemoveExpired() {
+	c.removeExpired(time.Now())
 }
 
 func (c *Cache[K, V]) removeExpired(now time.Time) {
 	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
 	// To avoid copying the expired entries if there's no eviction callback.
 	if c.onEviction == nil {
 		for key, entry := range c.m {
@@ -382,20 +442,19 @@ func (c *Cache[K, V]) removeExpired(now time.Time) {
 	}
 }
 
-// RemoveExpired removes all expired entries.
+// GetAll returns a copy of all entries in the cache.
 //
-// If an eviction callback is set, it is called for each removed entry.
-func (c *Cache[K, V]) RemoveExpired() {
-	c.removeExpired(time.Now())
-}
-
-type kv[K comparable, V any] struct {
-	key K
-	val V
+// If it encounters an expired entry, the expired entry is evicted.
+func (c *Cache[K, V]) GetAll() map[K]V {
+	return c.getAll(time.Now())
 }
 
 func (c *Cache[K, V]) getAll(now time.Time) map[K]V {
 	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil
+	}
 	// To avoid copying the expired entries if there's no eviction callback.
 	if c.onEviction == nil {
 		m := make(map[K]V, len(c.m))
@@ -435,11 +494,21 @@ func (c *Cache[K, V]) getAll(now time.Time) map[K]V {
 	return m
 }
 
-// GetAll returns a copy of all entries in the cache.
-//
-// If it encounters an expired entry, the expired entry is evicted.
-func (c *Cache[K, V]) GetAll() map[K]V {
-	return c.getAll(time.Now())
+type kv[K comparable, V any] struct {
+	key K
+	val V
+}
+
+// Len returns the number of entries in the cache.
+func (c *Cache[K, V]) Len() int {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return 0
+	}
+	n := c.len()
+	c.mu.Unlock()
+	return n
 }
 
 // len returns the number of entries in the cache.
@@ -448,29 +517,24 @@ func (c *Cache[K, V]) len() int {
 	return len(c.m)
 }
 
-// Len returns the number of entries in the cache.
-func (c *Cache[K, V]) Len() int {
+// Close closes the cache. It purges all entries and stops the cleaner
+// if it is running. After Close, all other methods are NOP returning
+// zero values immediately.
+func (c *Cache[K, V]) Close() {
 	c.mu.Lock()
-	n := c.len()
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
+	c.m = nil
+	c.closed = true
 	c.mu.Unlock()
-	return n
-}
-
-// StartCleaner starts a cleaner that periodically removes expired entries.
-// A cleaner runs in a separate goroutine.
-// It returns an error if the cleaner is already running
-// or if the interval is less than or equal to zero.
-//
-// The cleaner can be stopped by calling StopCleaner method.
-func (c *Cache[K, V]) StartCleaner(interval time.Duration) error {
-	return c.cleaner.start(c, interval)
-}
-
-// StopCleaner stops the cleaner.
-// It is a blocking method that waits for the cleaner to stop.
-// It's a NOP method if the cleaner is not running.
-func (c *Cache[K, V]) StopCleaner() {
-	c.cleaner.stop()
+	// If the cleaner is running, stop it.
+	// It's safe to access c.cleaner without a lock because
+	// it's only set during initialization and never modified.
+	if c.cleaner != nil {
+		c.cleaner.stop()
+	}
 }
 
 // NewSharded returns a new Sharded instance.
@@ -490,16 +554,30 @@ func NewSharded[K comparable, V any](n int, hasher Hasher64[K], opts ...Option[K
 	if hasher == nil {
 		panic("imcache: hasher must be not nil")
 	}
+	o := options[K, V]{defaultExp: noExp}
+	for _, opt := range opts {
+		opt.apply(&o)
+	}
+	cleanerInterval := o.cleanerInterval
+	// To prevent a cleaner from starting for each shard.
+	o.cleanerInterval = 0
 	shards := make([]*Cache[K, V], n)
 	for i := 0; i < n; i++ {
-		shards[i] = New(opts...)
+		shards[i] = newCache(o)
 	}
-	return &Sharded[K, V]{
-		shards:  shards,
-		hasher:  hasher,
-		mask:    uint64(n - 1),
-		cleaner: newCleaner(),
+	s := &Sharded[K, V]{
+		shards: shards,
+		hasher: hasher,
+		mask:   uint64(n - 1),
 	}
+	if cleanerInterval > 0 {
+		s.cleaner = newCleaner()
+		if err := s.cleaner.start(s, cleanerInterval); err != nil {
+			// With current sanitization this should never happen.
+			panic(err)
+		}
+	}
+	return s
 }
 
 // Sharded is a sharded in-memory cache.
@@ -640,6 +718,11 @@ func (s *Sharded[K, V]) GetAll() map[K]V {
 	ms := make([]map[K]V, 0, len(s.shards))
 	for _, shard := range s.shards {
 		m := shard.getAll(now)
+		// If Cache.getAll returns nil, it means that the shard is closed
+		// hence Sharded is closed too.
+		if m == nil {
+			return nil
+		}
 		n += len(m)
 		ms = append(ms, m)
 	}
@@ -661,19 +744,17 @@ func (s *Sharded[K, V]) Len() int {
 	return n
 }
 
-// StartCleaner starts a cleaner that periodically removes expired entries.
-// A cleaner runs in a separate goroutine.
-// It returns an error if the cleaner is already running
-// or if the interval is less than or equal to zero.
-//
-// The cleaner can be stopped by calling StopCleaner method.
-func (s *Sharded[K, V]) StartCleaner(interval time.Duration) error {
-	return s.cleaner.start(s, interval)
-}
-
-// StopCleaner stops the cleaner.
-// It is a blocking method that waits for the cleaner to stop.
-// It's a NOP method if the cleaner is not running.
-func (s *Sharded[K, V]) StopCleaner() {
-	s.cleaner.stop()
+// Close closes the cache. It purges all entries and stops the cleaner
+// if it is running. After Close, all other methods are NOP returning
+// zero values immediately.
+func (s *Sharded[K, V]) Close() {
+	for _, shard := range s.shards {
+		shard.Close()
+	}
+	// If the cleaner is running, stop it.
+	// It's safe to access s.cleaner without a lock because
+	// it's only set during initialization and never modified.
+	if s.cleaner != nil {
+		s.cleaner.stop()
+	}
 }

--- a/imcache.go
+++ b/imcache.go
@@ -64,6 +64,7 @@ func newCache[K comparable, V any](opts options[K, V]) *Cache[K, V] {
 //
 //	c := imcache.New[string, interface{}](
 //		imcache.WithDefaultExpirationOption[string, interface{}](time.Second),
+//		imcache.WithCleanerOption[string, interface{}](5*time.Minute),
 //		imcache.WithMaxEntriesOption[string, interface{}](10000),
 //		imcache.WithEvictionCallbackOption[string, interface{}](LogEvictedEntry),
 //	)
@@ -601,6 +602,7 @@ func NewSharded[K comparable, V any](n int, hasher Hasher64[K], opts ...Option[K
 //
 //	c := imcache.NewSharded[string, interface{}](8, imcache.DefaultStringHasher64{},
 //		imcache.WithDefaultExpirationOption[string, interface{}](time.Second),
+//		imcache.WithCleanerOption[string, interface{}](5*time.Minute),
 //		imcache.WithMaxEntriesOption[string, interface{}](10000),
 //		imcache.WithEvictionCallbackOption[string, interface{}](LogEvictedEntry),
 //	)

--- a/imcache_test.go
+++ b/imcache_test.go
@@ -24,8 +24,7 @@ type imcache[K comparable, V any] interface {
 	RemoveExpired()
 	GetAll() map[K]V
 	Len() int
-	StartCleaner(interval time.Duration) error
-	StopCleaner()
+	Close()
 }
 
 func TestImcache_Get(t *testing.T) {
@@ -868,6 +867,132 @@ func TestCache_DefaultSlidingExpiration_LessOrEqual0(t *testing.T) {
 	}
 }
 
+func TestImcache_Cleaner(t *testing.T) {
+	evictioncMock := &evictionCallbackMock{}
+
+	tests := []struct {
+		name string
+		c    imcache[string, interface{}]
+	}{
+		{
+			name: "not sharded",
+			c:    New(WithEvictionCallbackOption(evictioncMock.Callback), WithCleanerOption[string, interface{}](20*time.Millisecond)),
+		},
+		{
+			name: "sharded",
+			c:    NewSharded[string](8, DefaultStringHasher64{}, WithEvictionCallbackOption(evictioncMock.Callback), WithCleanerOption[string, interface{}](20*time.Millisecond)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer evictioncMock.Reset()
+			c := tt.c
+			c.Set("foo", "foo", WithExpiration(time.Millisecond))
+			c.Set("bar", "bar", WithExpiration(time.Millisecond))
+			c.Set("foobar", "foobar", WithExpiration(100*time.Millisecond))
+			<-time.After(30 * time.Millisecond)
+			if !evictioncMock.HasBeenCalledWith("foo", "foo", EvictionReasonExpired) {
+				t.Errorf("want EvictionCallback called with EvictionCallback(%s, %s, %d)", "foo", "foo", EvictionReasonExpired)
+			}
+			if !evictioncMock.HasBeenCalledWith("bar", "bar", EvictionReasonExpired) {
+				t.Errorf("want EvictionCallback called with EvictionCallback(%s, %s, %d)", "bar", "bar", EvictionReasonExpired)
+			}
+			if evictioncMock.HasBeenCalledWith("foobar", "foobar", EvictionReasonExpired) {
+				t.Errorf("want EvictionCallback not called with EvictionCallback(%s, %s, %d)", "foobar", "foobar", EvictionReasonExpired)
+			}
+			<-time.After(200 * time.Millisecond)
+			if !evictioncMock.HasBeenCalledWith("foobar", "foobar", EvictionReasonExpired) {
+				t.Errorf("want EvictionCallback called with EvictionCallback(%s, %s, %d)", "foobar", "foobar", EvictionReasonExpired)
+			}
+		})
+	}
+}
+
+func TestImcache_Cleaner_IntervalLessOrEqual0(t *testing.T) {
+	evictioncMock := &evictionCallbackMock{}
+
+	tests := []struct {
+		name string
+		c    imcache[string, interface{}]
+	}{
+		{
+			name: "not sharded",
+			c:    New(WithEvictionCallbackOption(evictioncMock.Callback), WithCleanerOption[string, interface{}](-1)),
+		},
+		{
+			name: "sharded",
+			c:    NewSharded[string](8, DefaultStringHasher64{}, WithEvictionCallbackOption(evictioncMock.Callback), WithCleanerOption[string, interface{}](0)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer evictioncMock.Reset()
+			c := tt.c
+			c.Set("foo", "foo", WithExpiration(time.Millisecond))
+			c.Set("bar", "bar", WithExpiration(time.Millisecond))
+			c.Set("foobar", "foobar", WithExpiration(100*time.Millisecond))
+			<-time.After(200 * time.Millisecond)
+			if !evictioncMock.HasNotBeenCalled() {
+				t.Error("want EvictionCallback not called")
+			}
+		})
+	}
+}
+
+func TestImcache_Close(t *testing.T) {
+	tests := []struct {
+		name string
+		c    imcache[string, string]
+	}{
+		{
+			name: "not sharded",
+			c:    New[string, string](WithCleanerOption[string, string](time.Millisecond)),
+		},
+		{
+			name: "sharded",
+			c:    NewSharded[string, string](8, DefaultStringHasher64{}, WithCleanerOption[string, string](time.Millisecond)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := tt.c
+			c.Close()
+			c.Set("foo", "foo", WithNoExpiration())
+			if _, ok := c.Get("foo"); ok {
+				t.Error("imcache.Get(_) = _, ok, want _, false")
+			}
+			v, ok := c.GetOrSet("foo", "bar", WithNoExpiration())
+			if ok {
+				t.Error("imcache.GetOrSet(_, _, _) = _, ok, want _, false")
+			}
+			if v != "" {
+				t.Errorf("imcache.GetOrSet(_, _, _) = %s, _, want %s, _", v, "")
+			}
+			if ok := c.Replace("foo", "bar", WithNoExpiration()); ok {
+				t.Error("imcache.Replace(_, _, _) = ok, want false")
+			}
+			if ok := c.ReplaceWithFunc("foo", func(string) string { return "bar" }, WithNoExpiration()); ok {
+				t.Error("imcache.ReplaceWithFunc(_, _, _) = ok, want false")
+			}
+			if ok := c.Remove("foo"); ok {
+				t.Error("imcache.Remove(_) = ok, want false")
+			}
+			if got := c.GetAll(); got != nil {
+				t.Errorf("imcache.GetAll() = %v, want nil", got)
+			}
+			if c.Len() != 0 {
+				t.Errorf("imcache.Len() = %d, want %d", c.Len(), 0)
+			}
+			c.RemoveAll()
+			c.RemoveExpired()
+			c.Close()
+		})
+	}
+}
+
 type evictionCallbackCall struct {
 	key    string
 	val    interface{}
@@ -1257,117 +1382,6 @@ func TestNewSharded_NilHasher(t *testing.T) {
 		}
 	}()
 	_ = NewSharded[string, string](2, nil)
-}
-
-func TestImcache_StartCleaner(t *testing.T) {
-	evictioncMock := &evictionCallbackMock{}
-
-	tests := []struct {
-		name string
-		c    imcache[string, interface{}]
-	}{
-		{
-			name: "not sharded",
-			c:    New(WithEvictionCallbackOption(evictioncMock.Callback)),
-		},
-		{
-			name: "sharded",
-			c:    NewSharded[string](8, DefaultStringHasher64{}, WithEvictionCallbackOption(evictioncMock.Callback)),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			defer evictioncMock.Reset()
-			c := tt.c
-			c.Set("foo", "foo", WithExpiration(time.Millisecond))
-			c.Set("bar", "bar", WithExpiration(time.Millisecond))
-			c.Set("foobar", "foobar", WithExpiration(100*time.Millisecond))
-			// StartCleaner should return an error if the interval is equal
-			// or less than 0.
-			if err := c.StartCleaner(0); err == nil {
-				t.Fatalf("Cache.StartCleaner(_) = nil, want error")
-			}
-			if err := c.StartCleaner(-10); err == nil {
-				t.Fatalf("Cache.StartCleaner(_) = nil, want error")
-			}
-			// Valid interval should start a cleaner.
-			if err := c.StartCleaner(20 * time.Millisecond); err != nil {
-				t.Fatalf("Cache.StartCleaner(_) = %v, want nil", err)
-			}
-			// Subsequent calls to StartCleaner should not start a new cleaner
-			// and should return an error.
-			if err := c.StartCleaner(5 * time.Nanosecond); err == nil {
-				t.Fatalf("Cache.StartCleaner(_) = nil, want error")
-			}
-			if err := c.StartCleaner(7 * time.Nanosecond); err == nil {
-				t.Fatalf("Cache.StartCleaner(_) = nil, want error")
-			}
-			<-time.After(30 * time.Millisecond)
-			if !evictioncMock.HasBeenCalledWith("foo", "foo", EvictionReasonExpired) {
-				t.Errorf("want EvictionCallback called with EvictionCallback(%s, %s, %d)", "foo", "foo", EvictionReasonExpired)
-			}
-			if !evictioncMock.HasBeenCalledWith("bar", "bar", EvictionReasonExpired) {
-				t.Errorf("want EvictionCallback called with EvictionCallback(%s, %s, %d)", "bar", "bar", EvictionReasonExpired)
-			}
-			if evictioncMock.HasBeenCalledWith("foobar", "foobar", EvictionReasonExpired) {
-				t.Errorf("want EvictionCallback not called with EvictionCallback(%s, %s, %d)", "foobar", "foobar", EvictionReasonExpired)
-			}
-			<-time.After(200 * time.Millisecond)
-			if !evictioncMock.HasBeenCalledWith("foobar", "foobar", EvictionReasonExpired) {
-				t.Errorf("want EvictionCallback called with EvictionCallback(%s, %s, %d)", "foobar", "foobar", EvictionReasonExpired)
-			}
-		})
-	}
-}
-
-func TestImcache_StopCleaner(t *testing.T) {
-	evictioncMock := &evictionCallbackMock{}
-
-	tests := []struct {
-		name string
-		c    imcache[string, interface{}]
-	}{
-		{
-			name: "not sharded",
-			c:    New(WithEvictionCallbackOption(evictioncMock.Callback)),
-		},
-		{
-			name: "sharded",
-			c:    NewSharded[string](8, DefaultStringHasher64{}, WithEvictionCallbackOption(evictioncMock.Callback)),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			defer evictioncMock.Reset()
-			c := tt.c
-			c.Set("foo", "foo", WithExpiration(time.Millisecond))
-			c.Set("bar", "bar", WithExpiration(time.Millisecond))
-			c.Set("foobar", "foobar", WithExpiration(100*time.Millisecond))
-			if err := c.StartCleaner(20 * time.Millisecond); err != nil {
-				t.Fatalf("Cache.StartCleaner(_) = %v, want nil", err)
-			}
-			<-time.After(30 * time.Millisecond)
-			if !evictioncMock.HasBeenCalledWith("foo", "foo", EvictionReasonExpired) {
-				t.Errorf("want EvictionCallback called with EvictionCallback(%s, %s, %d)", "foo", "foo", EvictionReasonExpired)
-			}
-			if !evictioncMock.HasBeenCalledWith("bar", "bar", EvictionReasonExpired) {
-				t.Errorf("want EvictionCallback called with EvictionCallback(%s, %s, %d)", "bar", "bar", EvictionReasonExpired)
-			}
-			if evictioncMock.HasBeenCalledWith("foobar", "foobar", EvictionReasonExpired) {
-				t.Errorf("want EvictionCallback not called with EvictionCallback(%s, %s, %d)", "foobar", "foobar", EvictionReasonExpired)
-			}
-			c.StopCleaner()
-			// Subsequent calls to StopCleaner should do nothing.
-			c.StopCleaner()
-			c.StopCleaner()
-			<-time.After(200 * time.Millisecond)
-			if evictioncMock.HasBeenCalledWith("foobar", "foobar", EvictionReasonExpired) {
-				t.Errorf("want EvictionCallback called with EvictionCallback(%s, %s, %d)", "foobar", "foobar", EvictionReasonExpired)
-			}
-		})
-	}
 }
 
 func TestCache_ZeroValue(t *testing.T) {

--- a/option.go
+++ b/option.go
@@ -70,15 +70,18 @@ func WithMaxEntriesOption[K comparable, V any](n int) Option[K, V] {
 }
 
 // WithCleanerOption returns an Option that sets a cache cleaner that
-// periodically removes expired entries from the cache. A cleaner
-// runs in a separate goroutine.
+// periodically removes expired entries from the cache.
+//
+// A cleaner runs in a separate goroutine. It removes expired entries
+// every interval. If the interval is less than or equal to zero,
+// the cleaner is disabled.
 //
 // A cleaner is stopped when the cache is closed.
-func WithCleanerOption[K comparable, V any](d time.Duration) Option[K, V] {
+func WithCleanerOption[K comparable, V any](interval time.Duration) Option[K, V] {
 	return optionf[K, V](func(o *options[K, V]) {
-		if d <= 0 {
+		if interval <= 0 {
 			return
 		}
-		o.cleanerInterval = d
+		o.cleanerInterval = interval
 	})
 }

--- a/option.go
+++ b/option.go
@@ -2,46 +2,55 @@ package imcache
 
 import "time"
 
-// Option configures the cache.
-type Option[K comparable, V any] interface {
-	apply(*Cache[K, V])
+// options holds the cache configuration.
+type options[K comparable, V any] struct {
+	onEviction      EvictionCallback[K, V]
+	defaultExp      time.Duration
+	sliding         bool
+	maxEntriesLimit int
+	cleanerInterval time.Duration
 }
 
-type optionf[K comparable, V any] func(*Cache[K, V])
+// Option configures the cache.
+type Option[K comparable, V any] interface {
+	apply(*options[K, V])
+}
+
+type optionf[K comparable, V any] func(*options[K, V])
 
 //lint:ignore U1000 false positive
-func (f optionf[K, V]) apply(c *Cache[K, V]) {
-	f(c)
+func (f optionf[K, V]) apply(o *options[K, V]) {
+	f(o)
 }
 
 // WithEvictionCallbackOption returns an Option that sets the cache
 // eviction callback.
 func WithEvictionCallbackOption[K comparable, V any](f EvictionCallback[K, V]) Option[K, V] {
-	return optionf[K, V](func(c *Cache[K, V]) {
-		c.onEviction = f
+	return optionf[K, V](func(o *options[K, V]) {
+		o.onEviction = f
 	})
 }
 
 // WithDefaultExpirationOption returns an Option that sets the cache
 // default expiration.
 func WithDefaultExpirationOption[K comparable, V any](d time.Duration) Option[K, V] {
-	return optionf[K, V](func(c *Cache[K, V]) {
+	return optionf[K, V](func(o *options[K, V]) {
 		if d <= 0 {
 			return
 		}
-		c.defaultExp = d
+		o.defaultExp = d
 	})
 }
 
 // WithDefaultSlidingExpirationOption returns an Option that sets the cache
 // default sliding expiration.
 func WithDefaultSlidingExpirationOption[K comparable, V any](d time.Duration) Option[K, V] {
-	return optionf[K, V](func(c *Cache[K, V]) {
+	return optionf[K, V](func(o *options[K, V]) {
 		if d <= 0 {
 			return
 		}
-		c.defaultExp = d
-		c.sliding = true
+		o.defaultExp = d
+		o.sliding = true
 	})
 }
 
@@ -52,11 +61,24 @@ func WithDefaultSlidingExpirationOption[K comparable, V any](d time.Duration) Op
 // If used with Sharded type, the maximum size is per shard,
 // not the total size of all shards.
 func WithMaxEntriesOption[K comparable, V any](n int) Option[K, V] {
-	return optionf[K, V](func(c *Cache[K, V]) {
+	return optionf[K, V](func(o *options[K, V]) {
 		if n <= 0 {
 			return
 		}
-		c.size = n
-		c.queue = &lruq[K]{}
+		o.maxEntriesLimit = n
+	})
+}
+
+// WithCleanerOption returns an Option that sets a cache cleaner that
+// periodically removes expired entries from the cache. A cleaner
+// runs in a separate goroutine.
+//
+// A cleaner is stopped when the cache is closed.
+func WithCleanerOption[K comparable, V any](d time.Duration) Option[K, V] {
+	return optionf[K, V](func(o *options[K, V]) {
+		if d <= 0 {
+			return
+		}
+		o.cleanerInterval = d
 	})
 }


### PR DESCRIPTION
This PR adds `Close` method to close the cache.

`Close` method closes the cache and stops the cleaner goroutine if it's running. After closing all cache methods are NOP. It can be annoying to not be able to close the cache when we're done with it. My issue was related to a graceful shutdown while multiple goroutines are still writing to and reading from the cache.

It also changes the cleaner API. I found `StartCleaner` and `StopCleaner` methods useless. Ultimately one wants to run the cleaner at the beginning or not at all.