### PR TITLE
Fix zero value `Cache` default expiration

### DIFF
--- a/imcache.go
+++ b/imcache.go
@@ -90,6 +90,7 @@ type Cache[K comparable, V any] struct {
 func (s *Cache[K, V]) init() {
 	if s.m == nil {
 		s.m = make(map[K]entry[K, V])
+		s.defaultExp = noExp
 		s.queue = &nopq[K]{}
 	}
 }

--- a/imcache_test.go
+++ b/imcache_test.go
@@ -1545,8 +1545,15 @@ func TestNewSharded_NilHasher(t *testing.T) {
 func TestCache_ZeroValue(t *testing.T) {
 	var c Cache[string, string]
 	c.Set("foo", "bar", WithNoExpiration())
-	if v, ok := c.Get("foo"); !ok || v != "bar" {
-		t.Errorf("want Cache.Get(_) = %s, true, got %s, %t", "bar", v, ok)
+	if got, ok := c.Get("foo"); !ok || got != "bar" {
+		t.Errorf("Cache.Get(%s) = %s, %t, want %s, %t", "foo", got, ok, "bar", true)
+	}
+	// Make sure the zero value Cache has default expiration
+	// set to no expiration.
+	c.Set("bar", "foo", WithDefaultExpiration())
+	<-time.After(time.Millisecond)
+	if got, ok := c.Get("bar"); !ok || got != "foo" {
+		t.Errorf("Cache.Get(%s) = %s, %t, want %s, %t", "bar", got, ok, "foo", true)
 	}
 }
 


### PR DESCRIPTION
This PR fixes `Cache` default expiration.

Before, `Cache` had `defaultExp` field set to 0 (integer zero value) meaning the entry always expires immediately after the expiration is set. This PR extends `init` method by setting default expiration to -1 (`noExp`).