### PR TITLE
Fix rand usage, typos and fields alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ func main() {
 
 * No expiration means that the entry will never expire.
 * Absolute expiration means that the entry will expire after a certain time.
-* Sliding expiration means that the entry will expire after a certain time if it hasn't been accessed. The expiration time is reset every time the entry is accessed. In other words the expiration time is slided to now + sliding expiration time where now is the time when the entry was accessed (read or write).
+* Sliding expiration means that the entry will expire after a certain time if it hasn't been accessed. The expiration time is reset every time the entry is accessed. In other words the expiration time is slided to now + sliding expiration time when now is the time when the entry was accessed (read or write).
 
 ```go
 // Set a new value with no expiration time.
@@ -65,7 +65,7 @@ c.Set(3, "three", imcache.WithExpirationDate(time.Now().Add(time.Second)))
 c.Set(4, "four", imcache.WithSlidingExpiration(time.Second))
 ```
 
-If you want to use default expiration time for the given cache instance, you can use the `WithDefaultExpiration` `Expiration` option. By default the default expiration time is set to no expiration. You can set the default expiration time when creating a new `Cache` or `Sharded` instance. More on sharding can be found in the [Sharding](#sharding) section.
+If you want to use default expiration time for the given cache instance, you can use the `WithDefaultExpiration` `Expiration` option. By default, the expiration time is set to no expiration. You can set the default expiration time when creating a new `Cache` or `Sharded` instance. More on sharding can be found in the [Sharding](#sharding) section.
 
 ```go
 // Create a new non-sharded cache instance with default absolute expiration time equal to 1 second.

--- a/cleaner.go
+++ b/cleaner.go
@@ -19,10 +19,10 @@ func newCleaner() *cleaner {
 }
 
 type cleaner struct {
-	mu      sync.Mutex
-	running bool
 	stopCh  chan struct{}
 	doneCh  chan struct{}
+	mu      sync.Mutex
+	running bool
 }
 
 func (c *cleaner) start(r eremover, interval time.Duration) error {

--- a/entry.go
+++ b/entry.go
@@ -5,8 +5,8 @@ import "time"
 // entry is the value stored in the cache.
 type entry[K comparable, V any] struct {
 	val  V
-	exp  expiration
 	node *node[K]
+	exp  expiration
 }
 
 // HasExpired returns true if the entry has expired.

--- a/entry_test.go
+++ b/entry_test.go
@@ -7,9 +7,9 @@ import (
 
 func TestEntry_HasExpired(t *testing.T) {
 	tests := []struct {
+		now   time.Time
 		name  string
 		entry entry[string, string]
-		now   time.Time
 		want  bool
 	}{
 		{
@@ -132,12 +132,12 @@ func TestEntry_HasSlidingExpiration(t *testing.T) {
 func TestEntry_SetDefault(t *testing.T) {
 	now := time.Now()
 	tests := []struct {
+		now     time.Time
 		name    string
 		entry   entry[string, string]
-		now     time.Time
+		want    entry[string, string]
 		d       time.Duration
 		sliding bool
-		want    entry[string, string]
 	}{
 		{
 			name:  "no expiration",

--- a/imcache_benchmark_test.go
+++ b/imcache_benchmark_test.go
@@ -26,7 +26,7 @@ func BenchmarkCache_Get(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if v, ok := c.Get(fmt.Sprintf("key-%d", rand.Intn(b.N))); ok {
-			_ = (token)(v)
+			_ = v
 		}
 	}
 }
@@ -43,7 +43,7 @@ func BenchmarkSharded_Get(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				if v, ok := c.Get(fmt.Sprintf("key-%d", rand.Intn(b.N))); ok {
-					_ = (token)(v)
+					_ = v
 				}
 			}
 		})
@@ -60,7 +60,7 @@ func BenchmarkCache_Get_MaxEntriesLimit(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if v, ok := c.Get(fmt.Sprintf("key-%d", rand.Intn(b.N))); ok {
-			_ = (token)(v)
+			_ = v
 		}
 	}
 }
@@ -77,7 +77,7 @@ func BenchmarkSharded_Get_MaxEntriesLimit(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				if v, ok := c.Get(fmt.Sprintf("key-%d", rand.Intn(b.N))); ok {
-					_ = (token)(v)
+					_ = v
 				}
 			}
 		})

--- a/imcache_test.go
+++ b/imcache_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func init() {
-	rand.Seed(time.Now().UnixNano())
+	rand.NewSource(time.Now().UnixNano())
 }
 
 type imcache[K comparable, V any] interface {
@@ -34,8 +34,8 @@ type imcache[K comparable, V any] interface {
 // If a test needs different type of cache or configured one, it should be
 // created within the test.
 var caches = []struct {
-	name   string
 	create func() imcache[string, string]
+	name   string
 }{
 	{
 		name: "Cache",
@@ -291,9 +291,9 @@ func TestImcache_Replace(t *testing.T) {
 }
 
 func TestImcache_ReplaceWithFunc(t *testing.T) {
-	var caches = []struct {
-		name   string
+	caches := []struct {
 		create func() imcache[string, int32]
+		name   string
 	}{
 		{
 			name:   "Cache",
@@ -305,10 +305,10 @@ func TestImcache_ReplaceWithFunc(t *testing.T) {
 		},
 	}
 	tests := []struct {
-		name    string
 		setup   func(imcache[string, int32])
-		key     string
 		f       func(int32) int32
+		name    string
+		key     string
 		val     int32
 		present bool
 	}{
@@ -357,12 +357,12 @@ func TestImcache_ReplaceWithFunc(t *testing.T) {
 
 func TestImcache_ReplaceKey(t *testing.T) {
 	tests := []struct {
-		name  string
 		setup func(imcache[string, string])
+		name  string
 		old   string
 		new   string
-		want  bool
 		val   string
+		want  bool
 	}{
 		{
 			name: "success",
@@ -584,8 +584,8 @@ func TestImcache_Len(t *testing.T) {
 
 func TestImcache_DefaultExpiration(t *testing.T) {
 	caches := []struct {
-		name   string
 		create func() imcache[string, string]
+		name   string
 	}{
 		{
 			name: "Cache",
@@ -621,8 +621,8 @@ func TestCache_DefaultExpiration_LessOrEqual0(t *testing.T) {
 
 func TestImcache_DefaultSlidingExpiration(t *testing.T) {
 	caches := []struct {
-		name   string
 		create func() imcache[string, string]
+		name   string
 	}{
 		{
 			name: "Cache",
@@ -668,14 +668,14 @@ func TestCache_DefaultSlidingExpiration_LessOrEqual0(t *testing.T) {
 }
 
 type evictionCallbackCall struct {
-	key    string
 	val    interface{}
+	key    string
 	reason EvictionReason
 }
 
 type evictionCallbackMock struct {
-	mu    sync.Mutex
 	calls []evictionCallbackCall
+	mu    sync.Mutex
 }
 
 func (m *evictionCallbackMock) Callback(key string, val interface{}, reason EvictionReason) {
@@ -740,8 +740,8 @@ func (m *evictionCallbackMock) Reset() {
 func TestImcache_Cleaner(t *testing.T) {
 	evictioncMock := &evictionCallbackMock{}
 	caches := []struct {
-		name   string
 		create func() imcache[string, interface{}]
+		name   string
 	}{
 		{
 			name: "Cache",
@@ -776,8 +776,8 @@ func TestImcache_Cleaner(t *testing.T) {
 func TestImcache_Cleaner_IntervalLessOrEqual0(t *testing.T) {
 	evictioncMock := &evictionCallbackMock{}
 	caches := []struct {
-		name   string
 		create func() imcache[string, interface{}]
+		name   string
 	}{
 		{
 			name: "Cache",
@@ -807,8 +807,8 @@ func TestImcache_Cleaner_IntervalLessOrEqual0(t *testing.T) {
 
 func TestImcache_Close(t *testing.T) {
 	caches := []struct {
-		name   string
 		create func() imcache[string, string]
+		name   string
 	}{
 		{
 			name: "Cache",
@@ -868,8 +868,8 @@ func TestImcache_Close(t *testing.T) {
 // If a test needs different type of cache or one with more sophisticated
 // configuration, it should be created within the test.
 var cachesWithEvictionCallback = []struct {
-	name   string
 	create func(EvictionCallback[string, interface{}]) imcache[string, interface{}]
+	name   string
 }{
 	{
 		name: "Cache",
@@ -1367,8 +1367,8 @@ func (c *longRunningEvictionCallback) Callback(key, value string, reason Evictio
 
 func TestImcache_LongRunning_EvictionCallback(t *testing.T) {
 	tests := []struct {
-		name    string
 		execute func(imcache[string, string])
+		name    string
 	}{
 		{
 			name: "Get evict expired entry",
@@ -1528,8 +1528,8 @@ func TestImcache_LongRunning_EvictionCallback(t *testing.T) {
 		},
 	}
 	caches := []struct {
-		name   string
 		create func(EvictionCallback[string, string]) imcache[string, string]
+		name   string
 	}{
 		{
 			name: "Cache",


### PR DESCRIPTION
- Some typos
- Fieldalignements, some bytes saved
- Rename s receiver to c to match others one
- Use NewSource instead of deprecated Seed ([more info](https://cs.opensource.google/go/go/+/go1.20.5:src/math/rand/rand.go;l=324))
- Simplify (token)(v)


<details>
  <summary>fieldalignements details</summary>
  
 
  ```bash
/home/greyxor/Documents/Projects/imcache/cleaner.go:21:14: struct with 32 pointer bytes could be 16
/home/greyxor/Documents/Projects/imcache/entry.go:6:33: struct with 40 pointer bytes could be 24
/home/greyxor/Documents/Projects/imcache/imcache.go:71:33: struct of size 80 could be 72
/home/greyxor/Documents/Projects/imcache/imcache.go:675:35: struct with 56 pointer bytes could be 32
/home/greyxor/Documents/Projects/imcache/entry_test.go:9:13: struct with 80 pointer bytes could be 72
/home/greyxor/Documents/Projects/imcache/entry_test.go:42:13: struct with 56 pointer bytes could be 48
/home/greyxor/Documents/Projects/imcache/entry_test.go:71:13: struct with 56 pointer bytes could be 48
/home/greyxor/Documents/Projects/imcache/entry_test.go:104:13: struct with 56 pointer bytes could be 48
/home/greyxor/Documents/Projects/imcache/entry_test.go:134:13: struct with 136 pointer bytes could be 112
/home/greyxor/Documents/Projects/imcache/imcache_test.go:36:16: struct with 24 pointer bytes could be 16
/home/greyxor/Documents/Projects/imcache/imcache_test.go:294:14: struct with 24 pointer bytes could be 16
/home/greyxor/Documents/Projects/imcache/imcache_test.go:307:13: struct with 48 pointer bytes could be 40
/home/greyxor/Documents/Projects/imcache/imcache_test.go:359:13: struct with 72 pointer bytes could be 64
/home/greyxor/Documents/Projects/imcache/imcache_test.go:586:14: struct with 24 pointer bytes could be 16
/home/greyxor/Documents/Projects/imcache/imcache_test.go:623:14: struct with 24 pointer bytes could be 16
/home/greyxor/Documents/Projects/imcache/imcache_test.go:670:27: struct with 32 pointer bytes could be 24
/home/greyxor/Documents/Projects/imcache/imcache_test.go:676:27: struct with 16 pointer bytes could be 8
/home/greyxor/Documents/Projects/imcache/imcache_test.go:742:14: struct with 24 pointer bytes could be 16
/home/greyxor/Documents/Projects/imcache/imcache_test.go:778:14: struct with 24 pointer bytes could be 16
/home/greyxor/Documents/Projects/imcache/imcache_test.go:809:14: struct with 24 pointer bytes could be 16
/home/greyxor/Documents/Projects/imcache/imcache_test.go:870:36: struct with 24 pointer bytes could be 16
/home/greyxor/Documents/Projects/imcache/imcache_test.go:1369:13: struct with 24 pointer bytes could be 16
/home/greyxor/Documents/Projects/imcache/imcache_test.go:1530:14: struct with 24 pointer bytes could be 16
/home/greyxor/Documents/Projects/imcache/entry_test.go:9:13: struct with 72 pointer bytes could be 64
/home/greyxor/Documents/Projects/imcache/entry_test.go:42:13: struct with 48 pointer bytes could be 40
/home/greyxor/Documents/Projects/imcache/entry_test.go:71:13: struct with 48 pointer bytes could be 40
/home/greyxor/Documents/Projects/imcache/entry_test.go:104:13: struct with 48 pointer bytes could be 40
/home/greyxor/Documents/Projects/imcache/entry_test.go:134:13: struct with 112 pointer bytes could be 104

  ```
  
</details>