### PR TITLE
Add GetAndRemove method

### DIFF
--- a/imcache.go
+++ b/imcache.go
@@ -249,9 +249,9 @@ func (c *Cache[K, V]) getAll(now time.Time) map[K]V {
 	return got
 }
 
-// GetAndDelete returns the value for the given key
+// GetAndRemove returns the value for the given key
 // and delete it even if it is not expired
-func (c *Cache[K, V]) GetAndDelete(key K) (V, bool) {
+func (c *Cache[K, V]) GetAndRemove(key K) (V, bool) {
 	now := nowf()
 	var zero V
 	c.mu.Lock()
@@ -896,10 +896,10 @@ func (s *Sharded[K, V]) Get(key K) (value V, present bool) {
 	return s.shard(key).Get(key)
 }
 
-// GetAndDelete returns the value for the given key and delete it even if it
+// GetAndRemove returns the value for the given key and delete it even if it
 //isn't expired
-func (s *Sharded[K, V]) GetAndDelete(key K) (value V, present bool) {
-	return s.shard(key).GetAndDelete(key)
+func (s *Sharded[K, V]) GetAndRemove(key K) (value V, present bool) {
+	return s.shard(key).GetAndRemove(key)
 }
 
 // GetMultiple returns the values for the given keys.

--- a/imcache.go
+++ b/imcache.go
@@ -249,6 +249,38 @@ func (c *Cache[K, V]) getAll(now time.Time) map[K]V {
 	return got
 }
 
+// GetAndDelete returns the value for the given key
+// and delete it even if it is not expired
+func (c *Cache[K, V]) GetAndDelete(key K) (V, bool) {
+	now := nowf()
+	var zero V
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return zero, false
+	}
+	node, ok := c.m[key]
+	if !ok {
+		return zero, false
+	}
+	entry := node.entry()
+	if entry.expired(now) {
+		c.queue.remove(node)
+		delete(c.m, key)
+		if c.onEviction != nil {
+			go c.onEviction(key, entry.val, EvictionReasonExpired)
+		}
+		return zero, false
+	}
+	entry.slide(now)
+	node.setEntry(entry)
+	c.queue.touch(node)
+
+	//delete after retrieve
+	delete(c.m, key)
+	return entry.val, true
+}
+
 // Peek returns the value for the given key without
 // actively evicting the entry if it is expired and
 // updating the entry's sliding expiration.
@@ -862,6 +894,12 @@ func (s *Sharded[K, V]) shardIndex(key K) int {
 // If it encounters an expired entry, the expired entry is evicted.
 func (s *Sharded[K, V]) Get(key K) (value V, present bool) {
 	return s.shard(key).Get(key)
+}
+
+// GetAndDelete returns the value for the given key and delete it even if it
+//isn't expired
+func (s *Sharded[K, V]) GetAndDelete(key K) (value V, present bool) {
+	return s.shard(key).GetAndDelete(key)
 }
 
 // GetMultiple returns the values for the given keys.

--- a/imcache_test.go
+++ b/imcache_test.go
@@ -33,7 +33,7 @@ func TestMain(m *testing.M) {
 
 type imcache[K comparable, V any] interface {
 	Get(key K) (v V, present bool)
-	GetAndDelete(key K) (v V, present bool)
+	GetAndRemove(key K) (v V, present bool)
 	GetMultiple(keys ...K) map[K]V
 	GetAll() map[K]V
 	Peek(key K) (v V, present bool)
@@ -942,8 +942,8 @@ func TestImcache_GetAll_SlidingExpiration(t *testing.T) {
 	}
 }
 
-//GetAndDelete Tests Init
-func TestImcache_GetAndDelete(t *testing.T) {
+//GetAndRemove Tests Init
+func TestImcache_GetAndRemove(t *testing.T) {
 	for _, cache := range caches {
 		t.Run(cache.name, func(t *testing.T) {
 			c := cache.create()
@@ -951,19 +951,19 @@ func TestImcache_GetAndDelete(t *testing.T) {
 			c.Set("foobar", "foobar", WithExpiration(time.Hour))
 
 			//get foobar item and delete it
-			c.GetAndDelete("foobar")
+			c.GetAndRemove("foobar")
 
 			got := c.GetAll()
 			want := map[string]string{
 				"foo": "foo",
 			}
 			if !reflect.DeepEqual(got, want) {
-				t.Errorf("imcache.GetAndDelete() = %v, want %v", got, want)
+				t.Errorf("imcache.GetAndRemove() = %v, want %v", got, want)
 			}
 		})
 	}
 }
-func TestImcache_GetAndDelete_Whit_Expiration(t *testing.T) {
+func TestImcache_GetAndRemove_Whit_Expiration(t *testing.T) {
 	for _, cache := range caches {
 		t.Run(cache.name, func(t *testing.T) {
 			c := cache.create()
@@ -975,20 +975,20 @@ func TestImcache_GetAndDelete_Whit_Expiration(t *testing.T) {
 			clock.AdvanceTime(300 * time.Millisecond)
 			//get foobar item and delete it
 			//bar gets deleted because expiration
-			c.GetAndDelete("foobar")
+			c.GetAndRemove("foobar")
 
 			got := c.GetAll()
 			want := map[string]string{
 				"foo": "foo",
 			}
 			if !reflect.DeepEqual(got, want) {
-				t.Errorf("imcache.GetAndDelete() = %v, want %v", got, want)
+				t.Errorf("imcache.GetAndRemove() = %v, want %v", got, want)
 			}
 		})
 	}
 }
 
-//GetAndDelete Tests End
+//GetAndRemove Tests End
 func TestImcache_Len(t *testing.T) {
 	for _, cache := range caches {
 		t.Run(cache.name, func(t *testing.T) {

--- a/imcache_test.go
+++ b/imcache_test.go
@@ -33,6 +33,7 @@ func TestMain(m *testing.M) {
 
 type imcache[K comparable, V any] interface {
 	Get(key K) (v V, present bool)
+	GetAndDelete(key K) (v V, present bool)
 	GetMultiple(keys ...K) map[K]V
 	GetAll() map[K]V
 	Peek(key K) (v V, present bool)
@@ -941,6 +942,53 @@ func TestImcache_GetAll_SlidingExpiration(t *testing.T) {
 	}
 }
 
+//GetAndDelete Tests Init
+func TestImcache_GetAndDelete(t *testing.T) {
+	for _, cache := range caches {
+		t.Run(cache.name, func(t *testing.T) {
+			c := cache.create()
+			c.Set("foo", "foo", WithNoExpiration())
+			c.Set("foobar", "foobar", WithExpiration(time.Hour))
+
+			//get foobar item and delete it
+			c.GetAndDelete("foobar")
+
+			got := c.GetAll()
+			want := map[string]string{
+				"foo": "foo",
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("imcache.GetAndDelete() = %v, want %v", got, want)
+			}
+		})
+	}
+}
+func TestImcache_GetAndDelete_Whit_Expiration(t *testing.T) {
+	for _, cache := range caches {
+		t.Run(cache.name, func(t *testing.T) {
+			c := cache.create()
+			c.Set("foo", "foo", WithNoExpiration())
+			c.Set("foobar", "foobar", WithExpiration(time.Hour))
+			c.Set("bar", "bar", WithExpiration(200*time.Nanosecond))
+
+			//advance time to force expiration
+			clock.AdvanceTime(300 * time.Millisecond)
+			//get foobar item and delete it
+			//bar gets deleted because expiration
+			c.GetAndDelete("foobar")
+
+			got := c.GetAll()
+			want := map[string]string{
+				"foo": "foo",
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("imcache.GetAndDelete() = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+//GetAndDelete Tests End
 func TestImcache_Len(t *testing.T) {
 	for _, cache := range caches {
 		t.Run(cache.name, func(t *testing.T) {


### PR DESCRIPTION
Write GetAndRemove method requested in issue #63 

This method keeps deleting if expired data is found just as in Get method.

Test with and without expiration are added to confirm that everything is working as expected.This tests can be easily found between //GetAndRemove Tests Init and //GetAndRemove Tests End

I know this can be done better to avoid redundant code (maybe in a future version, but i didn't want to change current logic too much, just add requested feature without side effects)

If this is not a wanted feature feel free to discard pull request.

Fixes: https://github.com/erni27/imcache/issues/63.
